### PR TITLE
Moving fermentation step based yeast (or bug) additions to yeast object

### DIFF
--- a/json/fermentation_step.json
+++ b/json/fermentation_step.json
@@ -43,13 +43,6 @@
         },
         "vessel": {
           "type": "string"
-        },
-        "microorganism_type": {
-          "type": "string",
-          "enum": ["Saccharomyces", "Brettanomyces", "Lactobacillus", "Pediococcus", "Other"]
-        },
-        "microorganism_name":{
-          "type": "string"
         }
       },
       "required": ["name"]

--- a/json/yeast.json
+++ b/json/yeast.json
@@ -15,7 +15,7 @@
         },
         "type": {
           "type": "string",
-          "enum": ["ale", "lager", "wheat", "wine", "champagne"]
+          "enum": ["ale", "lager", "wheat", "wine", "champagne", "bacteria", "mixed-culture"]
         },
         "form": {
           "type": "string",
@@ -93,8 +93,8 @@
               "times_cultured": {
                 "type": "integer"
               },
-              "add_to_secondary": {
-                "type": "boolean"
+              "add_to_fermentation_step": {
+                "type": "integer"
               },
               "amount": {
                 "$ref": "measureable_units.json#/definitions/VolumeType"


### PR DESCRIPTION
Per the discussion, I've changed add_to_secondary to be add_to_fermentation_step as an integer.  I've removed Microorganism_type and microorganism_name from the fermentation step object.  I've also added bacteria and mixed-culture as options for the yeast types.