### PR TITLE
Allow multiple entries in the root schema

### DIFF
--- a/js/__snapshots__/json-schema-to-markdown.test.js.snap
+++ b/js/__snapshots__/json-schema-to-markdown.test.js.snap
@@ -63,15 +63,6 @@ Parent: [FermentableBase](#fermentablebase)
 "
 `;
 
-exports[`formatObjectDefinition 1`] = `
-"### Properties
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-| **beerjson** | undefined|  | :white_check_mark: |
-"
-`;
-
 exports[`formatTypeDefinition 1`] = `
 "## FermentableBase 
 

--- a/js/json-schema-to-markdown.test.js
+++ b/js/json-schema-to-markdown.test.js
@@ -14,7 +14,3 @@ test('formatTypeDefinition', () => {
     ])
   ).toMatchSnapshot()
 })
-
-test('formatObjectDefinition', () => {
-  expect(parse.formatPropertyList(objSchema)).toMatchSnapshot()
-})

--- a/json/beer.json
+++ b/json/beer.json
@@ -6,136 +6,96 @@
   "additionalProperties": false,
   "properties": {
     "beerjson": {
-      "allOf": [
-        {
-          "type": "object",
-          "description": "Root element of all beerjson documents.",
-          "additionalProperties": false,
-          "properties": {
-            "version": {
-              "description":
-                "Explicitly encode beerjson version within list of records.",
-              "$ref": "measureable_units.json#/definitions/VersionType"
-            },
-            "fermentables": {
-              "type": "array",
-              "description":
-                "Records for any ingredient that contributes to the gravity of the beer.",
-              "items": {
-                "$ref": "fermentable.json#/definitions/FermentableType"
-              }
-            },
-            "miscellaneous_ingredients": {
-              "type": "array",
-              "description":
-                "Records for adjuncts which do not contribute to the gravity of the beer.",
-              "items": {
-                "$ref": "misc.json#/definitions/MiscellaneousType"
-              }
-            },
-            "hop_varieties": {
-              "type": "array",
-              "description":
-                "Records detailing the many properties of unique hop varieties.",
-              "items": {
-                "$ref": "hop.json#/definitions/VarietyInformation"
-              }
-            },
-            "cultures": {
-              "type": "array",
-              "description":
-                "Records detailing the wide array of unique cultures.",
-              "items": {
-                "$ref": "culture.json#/definitions/CultureInformation"
-              }
-            },
-            "profiles": {
-              "type": "array",
-              "description":
-                "Records for regional water profiles used in style-specific beer brewing.",
-              "items": {
-                "$ref": "water.json#/definitions/WaterType"
-              }
-            },
-            "styles": {
-              "type": "array",
-              "description":
-                "Records detailing the characteristics of the beer styles for which judging guidelines have been established.",
-              "items": {
-                "$ref": "style.json#/definitions/StyleType"
-              }
-            },
-            "procedures": {
-              "type": "array",
-              "description":
-                "A collection of steps providing process information for common mashing procedures.",
-              "items": {
-                "$ref": "mash.json#/definitions/MashProcedureType"
-              }
-            },
-            "fermentations": {
-              "type": "array",
-              "description":
-                "A collection of steps providing process information for common fermentation procedures.",
-              "items": {
-                "$ref":
-                  "fermentation.json#/definitions/FermentationProcedureType"
-              }
-            },
-            "recipes": {
-              "type": "array",
-              "description":
-                "Records containing a minimal collection of the description of ingredients, procedures and other required parameters necessary to recreate a batch of beer.",
-              "items": {
-                "$ref": "recipe.json#/definitions/RecipeType"
-              }
-            },
-            "equipments": {
-              "type": "array",
-              "description":
-                "Provides necessary information for brewing equipment.",
-              "items": {
-                "$ref": "equipment.json#/definitions/EquipmentType"
-              }
-            }
-          },
-          "required": ["version"]
+      "type": "object",
+      "description": "Root element of all beerjson documents.",
+      "additionalProperties": false,
+      "properties": {
+        "version": {
+          "description":
+            "Explicitly encode beerjson version within list of records.",
+          "$ref": "measureable_units.json#/definitions/VersionType"
         },
-        {
-          "oneOf": [
-            {
-              "required": ["fermentables"]
-            },
-            {
-              "required": ["miscellaneous_ingredients"]
-            },
-            {
-              "required": ["hop_varieties"]
-            },
-            {
-              "required": ["cultures"]
-            },
-            {
-              "required": ["profiles"]
-            },
-            {
-              "required": ["styles"]
-            },
-            {
-              "required": ["procedures"]
-            },
-            {
-              "required": ["fermentations"]
-            },
-            {
-              "required": ["recipes"]
-            },
-            {
-              "required": ["equipments"]
-            }
-          ]
+        "fermentables": {
+          "type": "array",
+          "description":
+            "Records for any ingredient that contributes to the gravity of the beer.",
+          "items": {
+            "$ref": "fermentable.json#/definitions/FermentableType"
+          }
+        },
+        "miscellaneous_ingredients": {
+          "type": "array",
+          "description":
+            "Records for adjuncts which do not contribute to the gravity of the beer.",
+          "items": {
+            "$ref": "misc.json#/definitions/MiscellaneousType"
+          }
+        },
+        "hop_varieties": {
+          "type": "array",
+          "description":
+            "Records detailing the many properties of unique hop varieties.",
+          "items": {
+            "$ref": "hop.json#/definitions/VarietyInformation"
+          }
+        },
+        "cultures": {
+          "type": "array",
+          "description": "Records detailing the wide array of unique cultures.",
+          "items": {
+            "$ref": "culture.json#/definitions/CultureInformation"
+          }
+        },
+        "profiles": {
+          "type": "array",
+          "description":
+            "Records for regional water profiles used in style-specific beer brewing.",
+          "items": {
+            "$ref": "water.json#/definitions/WaterType"
+          }
+        },
+        "styles": {
+          "type": "array",
+          "description":
+            "Records detailing the characteristics of the beer styles for which judging guidelines have been established.",
+          "items": {
+            "$ref": "style.json#/definitions/StyleType"
+          }
+        },
+        "procedures": {
+          "type": "array",
+          "description":
+            "A collection of steps providing process information for common mashing procedures.",
+          "items": {
+            "$ref": "mash.json#/definitions/MashProcedureType"
+          }
+        },
+        "fermentations": {
+          "type": "array",
+          "description":
+            "A collection of steps providing process information for common fermentation procedures.",
+          "items": {
+            "$ref": "fermentation.json#/definitions/FermentationProcedureType"
+          }
+        },
+        "recipes": {
+          "type": "array",
+          "description":
+            "Records containing a minimal collection of the description of ingredients, procedures and other required parameters necessary to recreate a batch of beer.",
+          "items": {
+            "$ref": "recipe.json#/definitions/RecipeType"
+          }
+        },
+        "equipments": {
+          "type": "array",
+          "description":
+            "Provides necessary information for brewing equipment.",
+          "items": {
+            "$ref": "equipment.json#/definitions/EquipmentType"
+          }
         }
-      ]
+      },
+      "required": ["version"]
     }
   },
   "required": ["beerjson"]

--- a/tests/generic/beer.json
+++ b/tests/generic/beer.json
@@ -1,0 +1,7 @@
+{
+  "beerjson": {
+    "version": 2.06,
+    "recipes": [],
+    "styles": []
+  }
+}

--- a/tests/samples.test.js
+++ b/tests/samples.test.js
@@ -48,6 +48,7 @@ const testXMLtoJSON = path => {
   })
 }
 
+testJson('generic/beer')
 testJson('generic/cultures')
 testJson('generic/equipment')
 testJson('generic/fermentable')


### PR DESCRIPTION
Original BeerXML 2 root schema contained an `xsd:choice` of several elements:
https://github.com/beerjson/beerjson/blob/master/xsd/BeerXML.xsd#L30-L114

This means that **one and only one** of these elements is allowed:
* fermentables
* miscellaneous_ingredients
* hop_varieties
* cultures
* profiles
* procedure
* recipes

This requirement (one and only one) complicates the root schema and is not very clear to me. 

So this pull requests is proposing to simplify the root schema. Only the **version** property is required, and multiple propreties are allowed to be in the same document. 

This will be a valid BeerJSON:
```
{
  "beerjson": {
    "version": 2.06,
    "recipes": [],
    "styles": []
  }
}
```
It would make things simpler, and allow you to combine several pieces of data when you need it.