### PR TITLE
Extract nested type definitions

### DIFF
--- a/docs/culture.json.md
+++ b/docs/culture.json.md
@@ -29,7 +29,7 @@ CultureInformation collects the attributes of a microbial culture to store as re
 | **notes** |  | string|  |
 | **best_for** |  | string|  |
 | **max_reuse** |  | integer|  |
-| **inventory** |  | :x: object|  |
+| **inventory** |  | [CultureInventoryType](#cultureinventorytype)|  |
 
 ## CultureAdditionType 
 
@@ -44,4 +44,17 @@ CultureAdditionType collects the attributes of each culture ingredient for use i
 | **timing** |  | [TimingType](timing.json.md#timingtype)|  |
 | **cell_count_billions** |  | integer|  |
 | **amount** |  |  [VolumeType](measureable_units.json.md#volumetype) or  [MassType](measureable_units.json.md#masstype) or  [UnitType](measureable_units.json.md#unittype)|  |
+
+## CultureInventoryType 
+
+*no description yet*
+
+**CultureInventoryType** is an object with these properties:
+
+|Name|Required|Type|Description|
+|--|--|--|--|
+| **liquid** |  | [VolumeType](measureable_units.json.md#volumetype)|  |
+| **dry** |  | [MassType](measureable_units.json.md#masstype)|  |
+| **slant** |  | [VolumeType](measureable_units.json.md#volumetype)|  |
+| **culture** |  | [VolumeType](measureable_units.json.md#volumetype)|  |
 

--- a/docs/fermentable.json.md
+++ b/docs/fermentable.json.md
@@ -13,7 +13,7 @@ FermentableBase provides unique properties to identify individual records of fer
 | **origin** |  | string|  |
 | **supplier** |  | string|  |
 | **grain_group** |  | `"base"`<br/>`"caramel"`<br/>`"flaked"`<br/>`"roasted"`<br/>`"specialty"`<br/>`"smoked"`<br/>`"adjunct"`|  |
-| **yield** | :white_check_mark: | :x: object|  |
+| **yield** | :white_check_mark: | [YieldType](#yieldtype)|  |
 | **color** | :white_check_mark: | [ColorType](measureable_units.json.md#colortype)|  |
 
 ## FermentableType 
@@ -32,7 +32,7 @@ FermentableType collects the attributes of a fermentable ingredient to store as 
 | **soluble_nitrogen_ratio** |  | number|  |
 | **max_in_batch** |  | [PercentType](measureable_units.json.md#percenttype)|  |
 | **recommend_mash** |  | boolean|  |
-| **inventory** |  | :x: object|  |
+| **inventory** |  | [FermentableInventoryType](#fermentableinventorytype)|  |
 
 ## FermentableAdditionType 
 
@@ -43,5 +43,28 @@ FermentableAdditionType collects the attributes of each fermentable ingredient f
 |Name|Required|Type|Description|
 |--|--|--|--|
 | **timing** |  | [TimingType](timing.json.md#timingtype)|  |
+| **amount** |  |  [VolumeType](measureable_units.json.md#volumetype) or  [MassType](measureable_units.json.md#masstype)|  |
+
+## YieldType 
+
+*no description yet*
+
+**YieldType** is an object with these properties:
+
+|Name|Required|Type|Description|
+|--|--|--|--|
+| **fine_grind** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+| **coarse_grind** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+| **fine_coarse_difference** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+| **potential** |  | [GravityType](measureable_units.json.md#gravitytype)|  |
+
+## FermentableInventoryType 
+
+*no description yet*
+
+**FermentableInventoryType** is an object with these properties:
+
+|Name|Required|Type|Description|
+|--|--|--|--|
 | **amount** |  |  [VolumeType](measureable_units.json.md#volumetype) or  [MassType](measureable_units.json.md#masstype)|  |
 

--- a/docs/hop.json.md
+++ b/docs/hop.json.md
@@ -26,8 +26,8 @@ VarietyInformation collects the attributes of a hop variety to store as record i
 | **notes** |  | string|  |
 | **percent_lost** |  | [PercentType](measureable_units.json.md#percenttype)|  |
 | **substitutes** |  | string|  |
-| **oil_content** |  | :x: object| oil_content collects all information of a hop variety pertaining to oil content, polyphenols, and thiols. |
-| **inventory** |  | :x: object|  |
+| **oil_content** |  | [OilContentType](#oilcontenttype)|  |
+| **inventory** |  | [HopInventoryType](#hopinventorytype)|  |
 
 ## HopAdditionType 
 
@@ -50,3 +50,36 @@ undefined
 *no description yet*
 
 `"Rager"`<br/>`"Tinseth"`<br/>`"Garetz"`<br/>`"Other"`
+## OilContentType 
+
+oil_content collects all information of a hop variety pertaining to oil content, polyphenols, and thiols.
+
+**OilContentType** is an object with these properties:
+
+|Name|Required|Type|Description|
+|--|--|--|--|
+| **total_oil_ml_per_100g** |  | number|  |
+| **humulene** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+| **caryophyllene** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+| **cohumulone** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+| **myrcene** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+| **farnesene** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+| **geraniol** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+| **b-pinene** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+| **linalool** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+| **limonene** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+| **nerol** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+| **pinene** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+| **polyphenols** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+| **xanthohumol** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+
+## HopInventoryType 
+
+*no description yet*
+
+**HopInventoryType** is an object with these properties:
+
+|Name|Required|Type|Description|
+|--|--|--|--|
+| **amount** |  |  [VolumeType](measureable_units.json.md#volumetype) or  [MassType](measureable_units.json.md#masstype)|  |
+

--- a/docs/misc.json.md
+++ b/docs/misc.json.md
@@ -21,7 +21,7 @@ MiscellaneousType collects the attributes of an ingredient to store as record in
 |--|--|--|--|
 | **use_for** |  | string|  |
 | **notes** |  | string|  |
-| **inventory** |  | :x: object|  |
+| **inventory** |  | [MiscellaneousInventoryType](#miscellaneousinventorytype)|  |
 
 ## MiscellaneousAdditionType 
 
@@ -33,4 +33,14 @@ MiscellaneousAdditionType collects the attributes of each miscellaneous ingredie
 |--|--|--|--|
 | **timing** |  | [TimingType](timing.json.md#timingtype)|  |
 | **amount** |  |  [VolumeType](measureable_units.json.md#volumetype) or  [MassType](measureable_units.json.md#masstype) or  [UnitType](measureable_units.json.md#unittype)|  |
+
+## MiscellaneousInventoryType 
+
+*no description yet*
+
+**MiscellaneousInventoryType** is an object with these properties:
+
+|Name|Required|Type|Description|
+|--|--|--|--|
+| **amount** | :white_check_mark: |  [VolumeType](measureable_units.json.md#volumetype) or  [MassType](measureable_units.json.md#masstype) or  [UnitType](measureable_units.json.md#unittype)|  |
 

--- a/docs/recipe.json.md
+++ b/docs/recipe.json.md
@@ -14,9 +14,9 @@ RecipeType composes the information stored in a beerjson recipe
 | **coauthor** |  | string|  |
 | **created** |  | [DateType](measureable_units.json.md#datetype)|  |
 | **batch_size** | :white_check_mark: | [VolumeType](measureable_units.json.md#volumetype)|  |
-| **efficiency** | :white_check_mark: | :x: object|  |
+| **efficiency** | :white_check_mark: | [EfficiencyType](#efficiencytype)|  |
 | **style** |  | [RecipeStyleType](style.json.md#recipestyletype)|  |
-| **ingredients** | :white_check_mark: | :x: object|  |
+| **ingredients** | :white_check_mark: | [IngredientsType](#ingredientstype)|  |
 | **mash** |  | [MashProcedureType](mash.json.md#mashproceduretype)|  |
 | **notes** |  | string|  |
 | **original_gravity** |  | [GravityType](measureable_units.json.md#gravitytype)|  |
@@ -29,6 +29,44 @@ RecipeType composes the information stored in a beerjson recipe
 | **fermentation** |  | [FermentationProcedureType](fermentation.json.md#fermentationproceduretype)|  |
 | **packaging** |  | [PackagingProcedureType](packaging.json.md#packagingproceduretype)|  |
 | **boil** |  | [BoilProcedureType](boil.json.md#boilproceduretype)|  |
-| **taste** |  | :x: object|  |
+| **taste** |  | [TasteType](#tastetype)|  |
 | **calories_per_pint** |  | number|  |
+
+## EfficiencyType 
+
+*no description yet*
+
+**EfficiencyType** is an object with these properties:
+
+|Name|Required|Type|Description|
+|--|--|--|--|
+| **conversion** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+| **lauter** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+| **mash** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+| **brewhouse** | :white_check_mark: | [PercentType](measureable_units.json.md#percenttype)|  |
+
+## IngredientsType 
+
+*no description yet*
+
+**IngredientsType** is an object with these properties:
+
+|Name|Required|Type|Description|
+|--|--|--|--|
+| **fermentable_additions** | :white_check_mark: | array of [FermentableAdditionType](fermentable.json.md#fermentableadditiontype)| fermentable_additions collects all the fermentable ingredients for use in a recipe |
+| **hop_additions** |  | array of [HopAdditionType](hop.json.md#hopadditiontype)| hop_additions collects all the hops for use in a recipe |
+| **miscellaneous_additions** |  | array of [MiscellaneousAdditionType](misc.json.md#miscellaneousadditiontype)| miscellaneous_additions collects all the miscellaneous items for use in a recipe |
+| **culture_additions** |  | array of [CultureAdditionType](culture.json.md#cultureadditiontype)| culture_additions collects all the culture items for use in a recipe |
+| **water_additions** |  | array of [WaterAdditionType](water.json.md#wateradditiontype)| water_additions collects all the water items for use in a recipe |
+
+## TasteType 
+
+*no description yet*
+
+**TasteType** is an object with these properties:
+
+|Name|Required|Type|Description|
+|--|--|--|--|
+| **notes** | :white_check_mark: | string|  |
+| **rating** | :white_check_mark: | number|  |
 

--- a/js/__snapshots__/json-schema-to-markdown.test.js.snap
+++ b/js/__snapshots__/json-schema-to-markdown.test.js.snap
@@ -16,7 +16,7 @@ FermentableBase provides unique properties to identify individual records of fer
 | **origin** |  | string|  |
 | **supplier** |  | string|  |
 | **grain_group** |  | \`\\"base\\"\`<br/>\`\\"caramel\\"\`<br/>\`\\"flaked\\"\`<br/>\`\\"roasted\\"\`<br/>\`\\"specialty\\"\`<br/>\`\\"smoked\\"\`<br/>\`\\"adjunct\\"\`|  |
-| **yield** | :white_check_mark: | :x: object|  |
+| **yield** | :white_check_mark: | [YieldType](#yieldtype)|  |
 | **color** | :white_check_mark: | [ColorType](measureable_units.json.md#colortype)|  |
 
 ## FermentableType 
@@ -35,7 +35,7 @@ FermentableType collects the attributes of a fermentable ingredient to store as 
 | **soluble_nitrogen_ratio** |  | number|  |
 | **max_in_batch** |  | [PercentType](measureable_units.json.md#percenttype)|  |
 | **recommend_mash** |  | boolean|  |
-| **inventory** |  | :x: object|  |
+| **inventory** |  | [FermentableInventoryType](#fermentableinventorytype)|  |
 
 ## FermentableAdditionType 
 
@@ -46,6 +46,29 @@ FermentableAdditionType collects the attributes of each fermentable ingredient f
 |Name|Required|Type|Description|
 |--|--|--|--|
 | **timing** |  | [TimingType](timing.json.md#timingtype)|  |
+| **amount** |  |  [VolumeType](measureable_units.json.md#volumetype) or  [MassType](measureable_units.json.md#masstype)|  |
+
+## YieldType 
+
+*no description yet*
+
+**YieldType** is an object with these properties:
+
+|Name|Required|Type|Description|
+|--|--|--|--|
+| **fine_grind** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+| **coarse_grind** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+| **fine_coarse_difference** |  | [PercentType](measureable_units.json.md#percenttype)|  |
+| **potential** |  | [GravityType](measureable_units.json.md#gravitytype)|  |
+
+## FermentableInventoryType 
+
+*no description yet*
+
+**FermentableInventoryType** is an object with these properties:
+
+|Name|Required|Type|Description|
+|--|--|--|--|
 | **amount** |  |  [VolumeType](measureable_units.json.md#volumetype) or  [MassType](measureable_units.json.md#masstype)|  |
 
 "
@@ -80,7 +103,7 @@ FermentableBase provides unique properties to identify individual records of fer
 | **origin** |  | string|  |
 | **supplier** |  | string|  |
 | **grain_group** |  | \`\\"base\\"\`<br/>\`\\"caramel\\"\`<br/>\`\\"flaked\\"\`<br/>\`\\"roasted\\"\`<br/>\`\\"specialty\\"\`<br/>\`\\"smoked\\"\`<br/>\`\\"adjunct\\"\`|  |
-| **yield** | :white_check_mark: | :x: object|  |
+| **yield** | :white_check_mark: | [YieldType](#yieldtype)|  |
 | **color** | :white_check_mark: | [ColorType](measureable_units.json.md#colortype)|  |
 
 "

--- a/json/culture.json
+++ b/json/culture.json
@@ -73,22 +73,7 @@
               "type": "integer"
             },
             "inventory": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "liquid": {
-                  "$ref": "measureable_units.json#/definitions/VolumeType"
-                },
-                "dry": {
-                  "$ref": "measureable_units.json#/definitions/MassType"
-                },
-                "slant": {
-                  "$ref": "measureable_units.json#/definitions/VolumeType"
-                },
-                "culture": {
-                  "$ref": "measureable_units.json#/definitions/VolumeType"
-                }
-              }
+              "$ref": "#/definitions/CultureInventoryType"
             }
           }
         }
@@ -134,6 +119,24 @@
           "required": ["amount"]
         }
       ]
+    },
+    "CultureInventoryType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "liquid": {
+          "$ref": "measureable_units.json#/definitions/VolumeType"
+        },
+        "dry": {
+          "$ref": "measureable_units.json#/definitions/MassType"
+        },
+        "slant": {
+          "$ref": "measureable_units.json#/definitions/VolumeType"
+        },
+        "culture": {
+          "$ref": "measureable_units.json#/definitions/VolumeType"
+        }
+      }
     }
   }
 }

--- a/json/fermentable.json
+++ b/json/fermentable.json
@@ -42,25 +42,7 @@
             "adjunct"
           ]
         },
-        "yield": {
-          "type": "object",
-          "minProperties": 1,
-          "additionalProperties": false,
-          "properties": {
-            "fine_grind": {
-              "$ref": "measureable_units.json#/definitions/PercentType"
-            },
-            "coarse_grind": {
-              "$ref": "measureable_units.json#/definitions/PercentType"
-            },
-            "fine_coarse_difference": {
-              "$ref": "measureable_units.json#/definitions/PercentType"
-            },
-            "potential": {
-              "$ref": "measureable_units.json#/definitions/GravityType"
-            }
-          }
-        },
+        "yield": { "$ref": "#/definitions/YieldType" },
         "color": {
           "$ref": "measureable_units.json#/definitions/ColorType"
         }
@@ -100,22 +82,7 @@
             "recommend_mash": {
               "type": "boolean"
             },
-            "inventory": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "amount": {
-                  "oneOf": [
-                    {
-                      "$ref": "measureable_units.json#/definitions/VolumeType"
-                    },
-                    {
-                      "$ref": "measureable_units.json#/definitions/MassType"
-                    }
-                  ]
-                }
-              }
-            }
+            "inventory": { "$ref": "#/definitions/FermentableInventoryType" }
           }
         }
       ]
@@ -146,6 +113,41 @@
           "required": ["amount"]
         }
       ]
+    },
+    "YieldType": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "properties": {
+        "fine_grind": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
+        },
+        "coarse_grind": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
+        },
+        "fine_coarse_difference": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
+        },
+        "potential": {
+          "$ref": "measureable_units.json#/definitions/GravityType"
+        }
+      }
+    },
+    "FermentableInventoryType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "amount": {
+          "oneOf": [
+            {
+              "$ref": "measureable_units.json#/definitions/VolumeType"
+            },
+            {
+              "$ref": "measureable_units.json#/definitions/MassType"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/json/hop.json
+++ b/json/hop.json
@@ -58,69 +58,9 @@
               "type": "string"
             },
             "oil_content": {
-              "type": "object",
-              "description": "oil_content collects all information of a hop variety pertaining to oil content, polyphenols, and thiols.",
-              "properties": {
-                "total_oil_ml_per_100g": {
-                  "type": "number"
-                },
-                "humulene": {
-                  "$ref": "measureable_units.json#/definitions/PercentType"
-                },
-                "caryophyllene": {
-                  "$ref": "measureable_units.json#/definitions/PercentType"
-                },
-                "cohumulone": {
-                  "$ref": "measureable_units.json#/definitions/PercentType"
-                },
-                "myrcene": {
-                  "$ref": "measureable_units.json#/definitions/PercentType"
-                },
-                "farnesene": {
-                  "$ref": "measureable_units.json#/definitions/PercentType"
-                },
-                "geraniol": {
-                  "$ref": "measureable_units.json#/definitions/PercentType"
-                },
-                "b-pinene": {
-                  "$ref": "measureable_units.json#/definitions/PercentType"
-                },
-                "linalool": {
-                  "$ref": "measureable_units.json#/definitions/PercentType"
-                },
-                "limonene": {
-                  "$ref": "measureable_units.json#/definitions/PercentType"
-                },
-                "nerol": {
-                  "$ref": "measureable_units.json#/definitions/PercentType"
-                },
-                "pinene": {
-                  "$ref": "measureable_units.json#/definitions/PercentType"
-                },
-                "polyphenols": {
-                  "$ref": "measureable_units.json#/definitions/PercentType"
-                },
-                "xanthohumol": {
-                  "$ref": "measureable_units.json#/definitions/PercentType"
-                }
-              }
+              "$ref": "#/definitions/OilContentType"
             },
-            "inventory": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "amount": {
-                  "oneOf": [
-                    {
-                      "$ref": "measureable_units.json#/definitions/VolumeType"
-                    },
-                    {
-                      "$ref": "measureable_units.json#/definitions/MassType"
-                    }
-                  ]
-                }
-              }
-            }
+            "inventory": { "$ref": "#/definitions/HopInventoryType" }
           }
         }
       ]
@@ -164,6 +104,70 @@
     "IBUMethodType": {
       "type": "string",
       "enum": ["Rager", "Tinseth", "Garetz", "Other"]
+    },
+    "OilContentType": {
+      "type": "object",
+      "description": "oil_content collects all information of a hop variety pertaining to oil content, polyphenols, and thiols.",
+      "properties": {
+        "total_oil_ml_per_100g": {
+          "type": "number"
+        },
+        "humulene": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
+        },
+        "caryophyllene": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
+        },
+        "cohumulone": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
+        },
+        "myrcene": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
+        },
+        "farnesene": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
+        },
+        "geraniol": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
+        },
+        "b-pinene": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
+        },
+        "linalool": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
+        },
+        "limonene": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
+        },
+        "nerol": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
+        },
+        "pinene": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
+        },
+        "polyphenols": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
+        },
+        "xanthohumol": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
+        }
+      }
+    },
+    "HopInventoryType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "amount": {
+          "oneOf": [
+            {
+              "$ref": "measureable_units.json#/definitions/VolumeType"
+            },
+            {
+              "$ref": "measureable_units.json#/definitions/MassType"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/json/misc.json
+++ b/json/misc.json
@@ -40,26 +40,7 @@
             "notes": {
               "type": "string"
             },
-            "inventory": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "amount": {
-                  "oneOf": [
-                    {
-                      "$ref": "measureable_units.json#/definitions/VolumeType"
-                    },
-                    {
-                      "$ref": "measureable_units.json#/definitions/MassType"
-                    },
-                    {
-                      "$ref": "measureable_units.json#/definitions/UnitType"
-                    }
-                  ]
-                }
-              },
-              "required": ["amount"]
-            }
+            "inventory": { "$ref": "#/definitions/MiscellaneousInventoryType" }
           }
         }
       ]
@@ -95,6 +76,26 @@
           "required": ["amount"]
         }
       ]
+    },
+    "MiscellaneousInventoryType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "amount": {
+          "oneOf": [
+            {
+              "$ref": "measureable_units.json#/definitions/VolumeType"
+            },
+            {
+              "$ref": "measureable_units.json#/definitions/MassType"
+            },
+            {
+              "$ref": "measureable_units.json#/definitions/UnitType"
+            }
+          ]
+        }
+      },
+      "required": ["amount"]
     }
   }
 }

--- a/json/recipe.json
+++ b/json/recipe.json
@@ -29,68 +29,13 @@
           "$ref": "measureable_units.json#/definitions/VolumeType"
         },
         "efficiency": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "conversion": {
-              "$ref": "measureable_units.json#/definitions/PercentType"
-            },
-            "lauter": {
-              "$ref": "measureable_units.json#/definitions/PercentType"
-            },
-            "mash": {
-              "$ref": "measureable_units.json#/definitions/PercentType"
-            },
-            "brewhouse": {
-              "$ref": "measureable_units.json#/definitions/PercentType"
-            }
-          },
-          "required": ["brewhouse"]
+          "$ref": "#/definitions/EfficiencyType"
         },
         "style": {
           "$ref": "style.json#/definitions/RecipeStyleType"
         },
         "ingredients": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "fermentable_additions": {
-              "type": "array",
-              "description": "fermentable_additions collects all the fermentable ingredients for use in a recipe",
-              "items": {
-                "$ref": "fermentable.json#/definitions/FermentableAdditionType"
-              }
-            },
-            "hop_additions": {
-              "type": "array",
-              "description": "hop_additions collects all the hops for use in a recipe",
-              "items": {
-                "$ref": "hop.json#/definitions/HopAdditionType"
-              }
-            },
-            "miscellaneous_additions": {
-              "type": "array",
-              "description": "miscellaneous_additions collects all the miscellaneous items for use in a recipe",
-              "items": {
-                "$ref": "misc.json#/definitions/MiscellaneousAdditionType"
-              }
-            },
-            "culture_additions": {
-              "type": "array",
-              "description": "culture_additions collects all the culture items for use in a recipe",
-              "items": {
-                "$ref": "culture.json#/definitions/CultureAdditionType"
-              }
-            },
-            "water_additions": {
-              "type": "array",
-              "description": "water_additions collects all the water items for use in a recipe",
-              "items": {
-                "$ref": "water.json#/definitions/WaterAdditionType"
-              }
-            }
-          },
-          "required": ["fermentable_additions"]
+          "$ref": "#/definitions/IngredientsType"
         },
         "mash": {
           "$ref": "mash.json#/definitions/MashProcedureType"
@@ -129,17 +74,7 @@
           "$ref": "boil.json#/definitions/BoilProcedureType"
         },
         "taste": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "notes": {
-              "type": "string"
-            },
-            "rating": {
-              "type": "number"
-            }
-          },
-          "required": ["notes", "rating"]
+          "$ref": "#/definitions/TasteType"
         },
         "calories_per_pint": {
           "type": "number"
@@ -153,6 +88,80 @@
         "batch_size",
         "ingredients"
       ]
+    },
+    "EfficiencyType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "conversion": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
+        },
+        "lauter": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
+        },
+        "mash": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
+        },
+        "brewhouse": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
+        }
+      },
+      "required": ["brewhouse"]
+    },
+    "IngredientsType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "fermentable_additions": {
+          "type": "array",
+          "description": "fermentable_additions collects all the fermentable ingredients for use in a recipe",
+          "items": {
+            "$ref": "fermentable.json#/definitions/FermentableAdditionType"
+          }
+        },
+        "hop_additions": {
+          "type": "array",
+          "description": "hop_additions collects all the hops for use in a recipe",
+          "items": {
+            "$ref": "hop.json#/definitions/HopAdditionType"
+          }
+        },
+        "miscellaneous_additions": {
+          "type": "array",
+          "description": "miscellaneous_additions collects all the miscellaneous items for use in a recipe",
+          "items": {
+            "$ref": "misc.json#/definitions/MiscellaneousAdditionType"
+          }
+        },
+        "culture_additions": {
+          "type": "array",
+          "description": "culture_additions collects all the culture items for use in a recipe",
+          "items": {
+            "$ref": "culture.json#/definitions/CultureAdditionType"
+          }
+        },
+        "water_additions": {
+          "type": "array",
+          "description": "water_additions collects all the water items for use in a recipe",
+          "items": {
+            "$ref": "water.json#/definitions/WaterAdditionType"
+          }
+        }
+      },
+      "required": ["fermentable_additions"]
+    },
+    "TasteType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "notes": {
+          "type": "string"
+        },
+        "rating": {
+          "type": "number"
+        }
+      },
+      "required": ["notes", "rating"]
     }
   }
 }


### PR DESCRIPTION
Nested type definitions are hard to render in the markdown, becaus it would require nested tables.
So i decided to extract such definitions into named types and leave references to those types.

This makes documentation straightforward.