### PR TITLE
Use alfa and beta acids as percents

### DIFF
--- a/docs/hop.json.md
+++ b/docs/hop.json.md
@@ -11,8 +11,8 @@ HopVarietyBase provides unique properties to identify individual records of a ho
 | **name** | ✅ | string|  |
 | **origin** |  | string|  |
 | **form** |  | `"extract"`<br/>`"leaf"`<br/>`"leaf (wet)"`<br/>`"pellet"`<br/>`"powder"`<br/>`"plug"`|  |
-| **alpha_acid_units** | ✅ | number|  |
-| **beta_acid_units** |  | number|  |
+| **alpha_acid** | ✅ | [PercentType](measureable_units.json.md#percenttype)|  |
+| **beta_acid** |  | [PercentType](measureable_units.json.md#percenttype)|  |
 
 ## VarietyInformation 
 

--- a/js/beerxml-to-beerjson.js
+++ b/js/beerxml-to-beerjson.js
@@ -156,11 +156,19 @@ const miscellaneous_additions = r =>
 const hop_bill = r =>
   _.map(getArrayNode(_.get(r, ['HOPS', 'HOP'])), hop => ({
     name: hop['NAME'],
-    alpha_acid_units: Number(hop['ALPHA']),
+    alpha_acid: {
+      unit: '%',
+      value: Number(hop['ALPHA'])
+    },
     ...(!_.isEmpty(hop['ORIGIN']) ? { origin: hop['ORIGIN'] } : {}),
     ...(!_.isEmpty(hop['FORM']) ? { form: _.lowerCase(hop['FORM']) } : {}),
     ...(!_.isEmpty(hop['BETA'])
-      ? { beta_acid_units: Number(hop['BETA']) }
+      ? {
+          beta_acid: {
+            unit: '%',
+            value: Number(hop['BETA'])
+          }
+        }
       : {}),
     ...(!_.isEmpty(hop['USE']) ? { use: _.lowerCase(hop['USE']) } : {}),
     amount: {

--- a/json/hop.json
+++ b/json/hop.json
@@ -18,14 +18,14 @@
           "type": "string",
           "enum": ["extract", "leaf", "leaf (wet)", "pellet", "powder", "plug"]
         },
-        "alpha_acid_units": {
-          "type": "number"
+        "alpha_acid": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
         },
-        "beta_acid_units": {
-          "type": "number"
+        "beta_acid": {
+          "$ref": "measureable_units.json#/definitions/PercentType"
         }
       },
-      "required": ["name", "alpha_acid_units"]
+      "required": ["name", "alpha_acid"]
     },
     "VarietyInformation": {
       "type": "object",
@@ -60,7 +60,9 @@
             "oil_content": {
               "$ref": "#/definitions/OilContentType"
             },
-            "inventory": { "$ref": "#/definitions/HopInventoryType" }
+            "inventory": {
+              "$ref": "#/definitions/HopInventoryType"
+            }
           }
         }
       ]

--- a/tests/converted/GenericOneHF.json
+++ b/tests/converted/GenericOneHF.json
@@ -8,12 +8,26 @@
         "author": "BIABrewer.info",
         "coauthor": "Designed by Lloyd Powell",
         "created": "2011-05-07T20:00:00.000Z",
-        "batch_size": { "unit": "l", "value": 19.0028767 },
-        "boil": {
-          "pre_boil_size": { "unit": "l", "value": 30.3767465 },
-          "boil_time": { "unit": "min", "value": 90 }
+        "batch_size": {
+          "unit": "l",
+          "value": 19.0028767
         },
-        "efficiency": { "brewhouse": { "unit": "%", "value": 70 } },
+        "boil": {
+          "pre_boil_size": {
+            "unit": "l",
+            "value": 30.3767465
+          },
+          "boil_time": {
+            "unit": "min",
+            "value": 90
+          }
+        },
+        "efficiency": {
+          "brewhouse": {
+            "unit": "%",
+            "value": 70
+          }
+        },
         "style": {
           "name": "K&#246;lsch",
           "category": "Light Hybrid Beer",
@@ -25,26 +39,49 @@
             {
               "name": "Pilsner (2 Row) Ger",
               "type": "grain",
-              "color": { "unit": "Lovi", "value": 2 },
-              "amount": { "unit": "kg", "value": 3.2412931 },
+              "color": {
+                "unit": "Lovi",
+                "value": 2
+              },
+              "amount": {
+                "unit": "kg",
+                "value": 3.2412931
+              },
               "origin": "Germany",
               "supplier": "",
               "group": "base",
-              "yield": { "potential": { "unit": "sg", "value": 1.03726 } },
+              "yield": {
+                "potential": {
+                  "unit": "sg",
+                  "value": 1.03726
+                }
+              },
               "add_after_boil": false
             }
           ],
           "hop_additions": [
             {
               "name": "Hallertauer",
-              "alpha_acid_units": 4.8,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 4.8
+              },
               "origin": "Germany",
               "form": "pellet",
-              "beta_acid_units": 4,
+              "beta_acid": {
+                "unit": "%",
+                "value": 4
+              },
               "use": "boil",
-              "amount": { "unit": "kg", "value": 0.0332677 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.0332677
+              },
               "timing": {
-                "time": { "unit": "min", "value": 60 },
+                "time": {
+                  "unit": "min",
+                  "value": 60
+                },
                 "use": "add_to_boil"
               }
             }
@@ -54,34 +91,67 @@
               "name": "Whirlfloc Tablet",
               "type": "fining",
               "use": "boil",
-              "amount": { "unit": "l", "value": 0.412685 }
+              "amount": {
+                "unit": "l",
+                "value": 0.412685
+              }
             }
           ],
           "culture_additions": [
             {
               "name": "German Ale",
-              "attenuation": { "unit": "%", "value": 75 },
+              "attenuation": {
+                "unit": "%",
+                "value": 75
+              },
               "type": "ale",
               "form": "liquid",
-              "amount": { "unit": "l", "value": 0.1242095 }
+              "amount": {
+                "unit": "l",
+                "value": 0.1242095
+              }
             }
           ]
         },
         "mash": {
           "name": "BIAB, Light Body",
-          "grain_temperature": { "unit": "C", "value": 22.2 },
-          "sparge_temperature": { "unit": "C", "value": 75.6 },
-          "pH": { "unit": "pH", "value": 5.2 },
+          "grain_temperature": {
+            "unit": "C",
+            "value": 22.2
+          },
+          "sparge_temperature": {
+            "unit": "C",
+            "value": 75.6
+          },
+          "pH": {
+            "unit": "pH",
+            "value": 5.2
+          },
           "notes": "Brew in a bag method where the full boil volume is mashed within the boil vessel and then the grains are withdrawn at the end of the mash.  No sparging.  This is a light body beer profile.",
           "mash_steps": [
             {
               "name": "Saccharification",
               "type": "infusion",
-              "step_temperature": { "unit": "C", "value": 65.5555556 },
-              "step_time": { "unit": "min", "value": 90 },
-              "ramp_time": { "unit": "min", "value": 10 },
-              "end_temperature": { "unit": "C", "value": 65.5555556 },
-              "amount": { "unit": "l", "value": 33.0186377 }
+              "step_temperature": {
+                "unit": "C",
+                "value": 65.5555556
+              },
+              "step_time": {
+                "unit": "min",
+                "value": 90
+              },
+              "ramp_time": {
+                "unit": "min",
+                "value": 10
+              },
+              "end_temperature": {
+                "unit": "C",
+                "value": 65.5555556
+              },
+              "amount": {
+                "unit": "l",
+                "value": 33.0186377
+              }
             }
           ]
         }

--- a/tests/converted/Kolsh.json
+++ b/tests/converted/Kolsh.json
@@ -8,12 +8,26 @@
         "author": "BIABrewer.info",
         "coauthor": "Designed by Lloyd Powell",
         "created": "2011-05-07T20:00:00.000Z",
-        "batch_size": { "unit": "l", "value": 19.0028767 },
-        "boil": {
-          "pre_boil_size": { "unit": "l", "value": 30.3767465 },
-          "boil_time": { "unit": "min", "value": 90 }
+        "batch_size": {
+          "unit": "l",
+          "value": 19.0028767
         },
-        "efficiency": { "brewhouse": { "unit": "%", "value": 70 } },
+        "boil": {
+          "pre_boil_size": {
+            "unit": "l",
+            "value": 30.3767465
+          },
+          "boil_time": {
+            "unit": "min",
+            "value": 90
+          }
+        },
+        "efficiency": {
+          "brewhouse": {
+            "unit": "%",
+            "value": 70
+          }
+        },
         "style": {
           "name": "K&#246;lsch",
           "category": "Light Hybrid Beer",
@@ -25,61 +39,118 @@
             {
               "name": "Pilsner (2 Row) Ger",
               "type": "grain",
-              "color": { "unit": "Lovi", "value": 2 },
-              "amount": { "unit": "kg", "value": 3.2412931 },
+              "color": {
+                "unit": "Lovi",
+                "value": 2
+              },
+              "amount": {
+                "unit": "kg",
+                "value": 3.2412931
+              },
               "origin": "Germany",
               "supplier": "",
               "group": "base",
-              "yield": { "potential": { "unit": "sg", "value": 1.03726 } },
+              "yield": {
+                "potential": {
+                  "unit": "sg",
+                  "value": 1.03726
+                }
+              },
               "add_after_boil": false
             },
             {
               "name": "Vienna Malt",
               "type": "grain",
-              "color": { "unit": "Lovi", "value": 3.4974619 },
-              "amount": { "unit": "kg", "value": 0.8640194 },
+              "color": {
+                "unit": "Lovi",
+                "value": 3.4974619
+              },
+              "amount": {
+                "unit": "kg",
+                "value": 0.8640194
+              },
               "origin": "Germany",
               "supplier": "",
               "group": "base",
-              "yield": { "potential": { "unit": "sg", "value": 1.03588 } },
+              "yield": {
+                "potential": {
+                  "unit": "sg",
+                  "value": 1.03588
+                }
+              },
               "add_after_boil": false
             },
             {
               "name": "Cara-Pils/Dextrine",
               "type": "grain",
-              "color": { "unit": "Lovi", "value": 2 },
-              "amount": { "unit": "kg", "value": 0.2164116 },
+              "color": {
+                "unit": "Lovi",
+                "value": 2
+              },
+              "amount": {
+                "unit": "kg",
+                "value": 0.2164116
+              },
               "origin": "US",
               "supplier": "",
               "group": "base",
-              "yield": { "potential": { "unit": "sg", "value": 1.03312 } },
+              "yield": {
+                "potential": {
+                  "unit": "sg",
+                  "value": 1.03312
+                }
+              },
               "add_after_boil": false
             }
           ],
           "hop_additions": [
             {
               "name": "Hallertauer",
-              "alpha_acid_units": 4.8,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 4.8
+              },
               "origin": "Germany",
               "form": "pellet",
-              "beta_acid_units": 4,
+              "beta_acid": {
+                "unit": "%",
+                "value": 4
+              },
               "use": "boil",
-              "amount": { "unit": "kg", "value": 0.0332677 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.0332677
+              },
               "timing": {
-                "time": { "unit": "min", "value": 60 },
+                "time": {
+                  "unit": "min",
+                  "value": 60
+                },
                 "use": "add_to_boil"
               }
             },
             {
               "name": "Hallertauer",
-              "alpha_acid_units": 4.8,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 4.8
+              },
               "origin": "Germany",
               "form": "pellet",
-              "beta_acid_units": 4,
+              "beta_acid": {
+                "unit": "%",
+                "value": 4
+              },
               "use": "boil",
-              "amount": { "unit": "kg", "value": 0.0166339 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.0166339
+              },
               "timing": {
-                "time": { "unit": "min", "value": 20 },
+                "time": {
+                  "unit": "min",
+                  "value": 20
+                },
                 "use": "add_to_boil"
               }
             }
@@ -89,43 +160,91 @@
               "name": "Whirlfloc Tablet",
               "type": "fining",
               "use": "boil",
-              "amount": { "unit": "l", "value": 0.412685 }
+              "amount": {
+                "unit": "l",
+                "value": 0.412685
+              }
             }
           ],
           "culture_additions": [
             {
               "name": "German Ale",
-              "attenuation": { "unit": "%", "value": 75 },
+              "attenuation": {
+                "unit": "%",
+                "value": 75
+              },
               "type": "ale",
               "form": "liquid",
-              "amount": { "unit": "l", "value": 0.1242095 }
+              "amount": {
+                "unit": "l",
+                "value": 0.1242095
+              }
             }
           ]
         },
         "mash": {
           "name": "BIAB, Light Body",
-          "grain_temperature": { "unit": "C", "value": 22.2 },
-          "sparge_temperature": { "unit": "C", "value": 75.6 },
-          "pH": { "unit": "pH", "value": 5.2 },
+          "grain_temperature": {
+            "unit": "C",
+            "value": 22.2
+          },
+          "sparge_temperature": {
+            "unit": "C",
+            "value": 75.6
+          },
+          "pH": {
+            "unit": "pH",
+            "value": 5.2
+          },
           "notes": "Brew in a bag method where the full boil volume is mashed within the boil vessel and then the grains are withdrawn at the end of the mash.  No sparging.  This is a light body beer profile.",
           "mash_steps": [
             {
               "name": "Saccharification",
               "type": "infusion",
-              "step_temperature": { "unit": "C", "value": 65.5555556 },
-              "step_time": { "unit": "min", "value": 90 },
-              "ramp_time": { "unit": "min", "value": 10 },
-              "end_temperature": { "unit": "C", "value": 65.5555556 },
-              "amount": { "unit": "l", "value": 33.0186377 }
+              "step_temperature": {
+                "unit": "C",
+                "value": 65.5555556
+              },
+              "step_time": {
+                "unit": "min",
+                "value": 90
+              },
+              "ramp_time": {
+                "unit": "min",
+                "value": 10
+              },
+              "end_temperature": {
+                "unit": "C",
+                "value": 65.5555556
+              },
+              "amount": {
+                "unit": "l",
+                "value": 33.0186377
+              }
             },
             {
               "name": "Mash Out",
               "type": "temperature",
-              "step_temperature": { "unit": "C", "value": 75.5555556 },
-              "step_time": { "unit": "min", "value": 10 },
-              "ramp_time": { "unit": "min", "value": 7 },
-              "end_temperature": { "unit": "C", "value": 75.5555556 },
-              "amount": { "unit": "l", "value": 0 }
+              "step_temperature": {
+                "unit": "C",
+                "value": 75.5555556
+              },
+              "step_time": {
+                "unit": "min",
+                "value": 10
+              },
+              "ramp_time": {
+                "unit": "min",
+                "value": 7
+              },
+              "end_temperature": {
+                "unit": "C",
+                "value": 75.5555556
+              },
+              "amount": {
+                "unit": "l",
+                "value": 0
+              }
             }
           ]
         }

--- a/tests/converted/Londonpride.json
+++ b/tests/converted/Londonpride.json
@@ -6,12 +6,26 @@
         "name": "London pride",
         "type": "all grain",
         "author": "RR",
-        "batch_size": { "unit": "l", "value": 40 },
-        "boil": {
-          "pre_boil_size": { "unit": "l", "value": 47 },
-          "boil_time": { "unit": "min", "value": 60 }
+        "batch_size": {
+          "unit": "l",
+          "value": 40
         },
-        "efficiency": { "brewhouse": { "unit": "%", "value": 65 } },
+        "boil": {
+          "pre_boil_size": {
+            "unit": "l",
+            "value": 47
+          },
+          "boil_time": {
+            "unit": "min",
+            "value": 60
+          }
+        },
+        "efficiency": {
+          "brewhouse": {
+            "unit": "%",
+            "value": 65
+          }
+        },
         "style": {
           "name": "Best Bitter",
           "category": "British Bitter",
@@ -23,44 +37,84 @@
             {
               "name": "Pale 2-Row",
               "type": "grain",
-              "color": { "unit": "Lovi", "value": 2.5 },
-              "amount": { "unit": "kg", "value": 9 },
+              "color": {
+                "unit": "Lovi",
+                "value": 2.5
+              },
+              "amount": {
+                "unit": "kg",
+                "value": 9
+              },
               "origin": "United Kingdom",
               "group": "base",
-              "yield": { "potential": { "unit": "sg", "value": 1.0380006 } },
+              "yield": {
+                "potential": {
+                  "unit": "sg",
+                  "value": 1.0380006
+                }
+              },
               "add_after_boil": false
             },
             {
               "name": "Cara Plus 200",
               "type": "grain",
-              "color": { "unit": "Lovi", "value": 76 },
-              "amount": { "unit": "kg", "value": 0.6 },
+              "color": {
+                "unit": "Lovi",
+                "value": 76
+              },
+              "amount": {
+                "unit": "kg",
+                "value": 0.6
+              },
               "origin": "Finland",
               "group": "base",
-              "yield": { "potential": { "unit": "sg", "value": 1.0350014 } },
+              "yield": {
+                "potential": {
+                  "unit": "sg",
+                  "value": 1.0350014
+                }
+              },
               "add_after_boil": false
             }
           ],
           "hop_additions": [
             {
               "name": "Target",
-              "alpha_acid_units": 11.5,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 11.5
+              },
               "form": "pellet",
               "use": "boil",
-              "amount": { "unit": "kg", "value": 0.03 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.03
+              },
               "timing": {
-                "time": { "unit": "min", "value": 60 },
+                "time": {
+                  "unit": "min",
+                  "value": 60
+                },
                 "use": "add_to_boil"
               }
             },
             {
               "name": "Target",
-              "alpha_acid_units": 11.5,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 11.5
+              },
               "form": "pellet",
               "use": "boil",
-              "amount": { "unit": "kg", "value": 0.03 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.03
+              },
               "timing": {
-                "time": { "unit": "min", "value": 15 },
+                "time": {
+                  "unit": "min",
+                  "value": 15
+                },
                 "use": "add_to_boil"
               }
             }
@@ -68,22 +122,37 @@
           "culture_additions": [
             {
               "name": "English Ale Yeast WLP002",
-              "attenuation": { "unit": "%", "value": 66.5 },
+              "attenuation": {
+                "unit": "%",
+                "value": 66.5
+              },
               "type": "ale",
               "form": "liquid",
-              "amount": { "unit": "l", "value": 0.1 }
+              "amount": {
+                "unit": "l",
+                "value": 0.1
+              }
             }
           ]
         },
         "mash": {
           "name": "Mash Steps",
-          "grain_temperature": { "unit": "C", "value": 20 },
+          "grain_temperature": {
+            "unit": "C",
+            "value": 20
+          },
           "mash_steps": [
             {
               "name": "",
               "type": "temperature",
-              "step_temperature": { "unit": "C", "value": 65 },
-              "step_time": { "unit": "min", "value": 60 }
+              "step_temperature": {
+                "unit": "C",
+                "value": 65
+              },
+              "step_time": {
+                "unit": "min",
+                "value": 60
+              }
             }
           ]
         }

--- a/tests/converted/RRSummerBitter.json
+++ b/tests/converted/RRSummerBitter.json
@@ -7,12 +7,26 @@
         "type": "all grain",
         "author": "RomaRoma",
         "created": "2017-07-13T21:00:00.000Z",
-        "batch_size": { "unit": "l", "value": 40 },
-        "boil": {
-          "pre_boil_size": { "unit": "l", "value": 45.6427168 },
-          "boil_time": { "unit": "min", "value": 60 }
+        "batch_size": {
+          "unit": "l",
+          "value": 40
         },
-        "efficiency": { "brewhouse": { "unit": "%", "value": 75 } },
+        "boil": {
+          "pre_boil_size": {
+            "unit": "l",
+            "value": 45.6427168
+          },
+          "boil_time": {
+            "unit": "min",
+            "value": 60
+          }
+        },
+        "efficiency": {
+          "brewhouse": {
+            "unit": "%",
+            "value": 75
+          }
+        },
         "style": {
           "name": "English Best Bitter",
           "category": "Bitter Ale",
@@ -24,63 +38,121 @@
             {
               "name": "Pale Malt, Maris Otter",
               "type": "grain",
-              "color": { "unit": "Lovi", "value": 3 },
-              "amount": { "unit": "kg", "value": 6.9999955 },
+              "color": {
+                "unit": "Lovi",
+                "value": 3
+              },
+              "amount": {
+                "unit": "kg",
+                "value": 6.9999955
+              },
               "origin": "United Kingdom",
               "supplier": "Maris Otter",
               "group": "base",
-              "yield": { "potential": { "unit": "sg", "value": 1.03795 } },
+              "yield": {
+                "potential": {
+                  "unit": "sg",
+                  "value": 1.03795
+                }
+              },
               "add_after_boil": false
             },
             {
               "name": "Cara 50",
               "type": "grain",
-              "color": { "unit": "Lovi", "value": 25.3807107 },
-              "amount": { "unit": "kg", "value": 0.9999994 },
+              "color": {
+                "unit": "Lovi",
+                "value": 25.3807107
+              },
+              "amount": {
+                "unit": "kg",
+                "value": 0.9999994
+              },
               "origin": "Belgium",
               "supplier": "",
               "group": "base",
-              "yield": { "potential": { "unit": "sg", "value": 1.0345 } },
+              "yield": {
+                "potential": {
+                  "unit": "sg",
+                  "value": 1.0345
+                }
+              },
               "add_after_boil": false
             }
           ],
           "hop_additions": [
             {
               "name": "Target",
-              "alpha_acid_units": 11,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 11
+              },
               "origin": "United Kingdom",
               "form": "pellet",
-              "beta_acid_units": 5,
+              "beta_acid": {
+                "unit": "%",
+                "value": 5
+              },
               "use": "boil",
-              "amount": { "unit": "kg", "value": 0.04 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.04
+              },
               "timing": {
-                "time": { "unit": "min", "value": 60 },
+                "time": {
+                  "unit": "min",
+                  "value": 60
+                },
                 "use": "add_to_boil"
               }
             },
             {
               "name": "Goldings, East Kent",
-              "alpha_acid_units": 5,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 5
+              },
               "origin": "United Kingdom",
               "form": "pellet",
-              "beta_acid_units": 3.5,
+              "beta_acid": {
+                "unit": "%",
+                "value": 3.5
+              },
               "use": "boil",
-              "amount": { "unit": "kg", "value": 0.015 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.015
+              },
               "timing": {
-                "time": { "unit": "min", "value": 30 },
+                "time": {
+                  "unit": "min",
+                  "value": 30
+                },
                 "use": "add_to_boil"
               }
             },
             {
               "name": "Goldings, East Kent",
-              "alpha_acid_units": 5,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 5
+              },
               "origin": "United Kingdom",
               "form": "pellet",
-              "beta_acid_units": 3.5,
+              "beta_acid": {
+                "unit": "%",
+                "value": 3.5
+              },
               "use": "boil",
-              "amount": { "unit": "kg", "value": 0.015 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.015
+              },
               "timing": {
-                "time": { "unit": "min", "value": 15 },
+                "time": {
+                  "unit": "min",
+                  "value": 15
+                },
                 "use": "add_to_boil"
               }
             }
@@ -88,37 +160,82 @@
           "culture_additions": [
             {
               "name": "Windsor Yeast",
-              "attenuation": { "unit": "%", "value": 75 },
+              "attenuation": {
+                "unit": "%",
+                "value": 75
+              },
               "type": "ale",
               "form": "dry",
-              "amount": { "unit": "l", "value": 0.023659 }
+              "amount": {
+                "unit": "l",
+                "value": 0.023659
+              }
             }
           ]
         },
         "mash": {
           "name": "Temperature Mash, 1 Step, Full Body",
-          "grain_temperature": { "unit": "C", "value": 22.2222222 },
-          "sparge_temperature": { "unit": "C", "value": 75.5555556 },
-          "pH": { "unit": "pH", "value": 5.4 },
+          "grain_temperature": {
+            "unit": "C",
+            "value": 22.2222222
+          },
+          "sparge_temperature": {
+            "unit": "C",
+            "value": 75.5555556
+          },
+          "pH": {
+            "unit": "pH",
+            "value": 5.4
+          },
           "notes": "Temperature mash for use when mashing in a brew pot over a heat source such as the stove.  Use heat to maintain desired temperature during the mash.",
           "mash_steps": [
             {
               "name": "Saccharification",
               "type": "infusion",
-              "step_temperature": { "unit": "C", "value": 68.8888889 },
-              "step_time": { "unit": "min", "value": 40 },
-              "ramp_time": { "unit": "min", "value": 15 },
-              "end_temperature": { "unit": "C", "value": 68.8888889 },
-              "amount": { "unit": "l", "value": 20.8636349 }
+              "step_temperature": {
+                "unit": "C",
+                "value": 68.8888889
+              },
+              "step_time": {
+                "unit": "min",
+                "value": 40
+              },
+              "ramp_time": {
+                "unit": "min",
+                "value": 15
+              },
+              "end_temperature": {
+                "unit": "C",
+                "value": 68.8888889
+              },
+              "amount": {
+                "unit": "l",
+                "value": 20.8636349
+              }
             },
             {
               "name": "Mash Out",
               "type": "temperature",
-              "step_temperature": { "unit": "C", "value": 75.5555556 },
-              "step_time": { "unit": "min", "value": 10 },
-              "ramp_time": { "unit": "min", "value": 10 },
-              "end_temperature": { "unit": "C", "value": 75.5555556 },
-              "amount": { "unit": "l", "value": 0 }
+              "step_temperature": {
+                "unit": "C",
+                "value": 75.5555556
+              },
+              "step_time": {
+                "unit": "min",
+                "value": 10
+              },
+              "ramp_time": {
+                "unit": "min",
+                "value": 10
+              },
+              "end_temperature": {
+                "unit": "C",
+                "value": 75.5555556
+              },
+              "amount": {
+                "unit": "l",
+                "value": 0
+              }
             }
           ]
         }

--- a/tests/converted/punk-ipa-2010-current.json
+++ b/tests/converted/punk-ipa-2010-current.json
@@ -6,197 +6,401 @@
         "name": "PUNK IPA 2010 - CURRENT",
         "type": "all grain",
         "author": "BREWDOG",
-        "batch_size": { "unit": "l", "value": 20 },
-        "boil": {
-          "pre_boil_size": { "unit": "l", "value": 25 },
-          "boil_time": { "unit": "min", "value": 60 }
+        "batch_size": {
+          "unit": "l",
+          "value": 20
         },
-        "efficiency": { "brewhouse": { "unit": "%", "value": 79.25 } },
+        "boil": {
+          "pre_boil_size": {
+            "unit": "l",
+            "value": 25
+          },
+          "boil_time": {
+            "unit": "min",
+            "value": 60
+          }
+        },
+        "efficiency": {
+          "brewhouse": {
+            "unit": "%",
+            "value": 79.25
+          }
+        },
         "ingredients": {
           "fermentable_additions": [
             {
               "name": "Extra Pale",
               "type": "grain",
-              "color": { "unit": "Lovi", "value": 2 },
-              "amount": { "unit": "kg", "value": 4.38 },
+              "color": {
+                "unit": "Lovi",
+                "value": 2
+              },
+              "amount": {
+                "unit": "kg",
+                "value": 4.38
+              },
               "group": "base",
-              "yield": { "potential": { "unit": "sg", "value": 1.03772 } }
+              "yield": {
+                "potential": {
+                  "unit": "sg",
+                  "value": 1.03772
+                }
+              }
             },
             {
               "name": "Caramalt",
               "type": "grain",
-              "color": { "unit": "Lovi", "value": 15 },
-              "amount": { "unit": "kg", "value": 0.25 },
+              "color": {
+                "unit": "Lovi",
+                "value": 15
+              },
+              "amount": {
+                "unit": "kg",
+                "value": 0.25
+              },
               "group": "base",
-              "yield": { "potential": { "unit": "sg", "value": 1.03266 } }
+              "yield": {
+                "potential": {
+                  "unit": "sg",
+                  "value": 1.03266
+                }
+              }
             }
           ],
           "hop_additions": [
             {
               "name": "Chinook",
-              "alpha_acid_units": 12.6,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 12.6
+              },
               "form": "pellet",
-              "beta_acid_units": 0,
+              "beta_acid": {
+                "unit": "%",
+                "value": 0
+              },
               "use": "boil",
-              "amount": { "unit": "kg", "value": 0.02 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.02
+              },
               "timing": {
-                "time": { "unit": "min", "value": 60 },
+                "time": {
+                  "unit": "min",
+                  "value": 60
+                },
                 "use": "add_to_boil"
               }
             },
             {
               "name": "Ahtanum",
-              "alpha_acid_units": 5.4,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 5.4
+              },
               "form": "pellet",
-              "beta_acid_units": 0,
+              "beta_acid": {
+                "unit": "%",
+                "value": 0
+              },
               "use": "boil",
-              "amount": { "unit": "kg", "value": 0.0125 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.0125
+              },
               "timing": {
-                "time": { "unit": "min", "value": 60 },
+                "time": {
+                  "unit": "min",
+                  "value": 60
+                },
                 "use": "add_to_boil"
               }
             },
             {
               "name": "Chinook",
-              "alpha_acid_units": 12.6,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 12.6
+              },
               "form": "pellet",
-              "beta_acid_units": 0,
+              "beta_acid": {
+                "unit": "%",
+                "value": 0
+              },
               "use": "boil",
-              "amount": { "unit": "kg", "value": 0.02 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.02
+              },
               "timing": {
-                "time": { "unit": "min", "value": 30 },
+                "time": {
+                  "unit": "min",
+                  "value": 30
+                },
                 "use": "add_to_boil"
               }
             },
             {
               "name": "Ahtanum",
-              "alpha_acid_units": 5.4,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 5.4
+              },
               "form": "pellet",
-              "beta_acid_units": 0,
+              "beta_acid": {
+                "unit": "%",
+                "value": 0
+              },
               "use": "boil",
-              "amount": { "unit": "kg", "value": 0.0125 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.0125
+              },
               "timing": {
-                "time": { "unit": "min", "value": 30 },
+                "time": {
+                  "unit": "min",
+                  "value": 30
+                },
                 "use": "add_to_boil"
               }
             },
             {
               "name": "Chinook",
-              "alpha_acid_units": 12.6,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 12.6
+              },
               "form": "pellet",
-              "beta_acid_units": 0,
+              "beta_acid": {
+                "unit": "%",
+                "value": 0
+              },
               "use": "boil",
-              "amount": { "unit": "kg", "value": 0.0275 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.0275
+              },
               "timing": {
-                "time": { "unit": "min", "value": 0 },
+                "time": {
+                  "unit": "min",
+                  "value": 0
+                },
                 "use": "add_to_boil"
               }
             },
             {
               "name": "Ahtanum",
-              "alpha_acid_units": 5.4,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 5.4
+              },
               "form": "pellet",
-              "beta_acid_units": 0,
+              "beta_acid": {
+                "unit": "%",
+                "value": 0
+              },
               "use": "boil",
-              "amount": { "unit": "kg", "value": 0.0125 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.0125
+              },
               "timing": {
-                "time": { "unit": "min", "value": 0 },
+                "time": {
+                  "unit": "min",
+                  "value": 0
+                },
                 "use": "add_to_boil"
               }
             },
             {
               "name": "Simcoe",
-              "alpha_acid_units": 12.8,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 12.8
+              },
               "form": "pellet",
-              "beta_acid_units": 0,
+              "beta_acid": {
+                "unit": "%",
+                "value": 0
+              },
               "use": "boil",
-              "amount": { "unit": "kg", "value": 0.0125 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.0125
+              },
               "timing": {
-                "time": { "unit": "min", "value": 0 },
+                "time": {
+                  "unit": "min",
+                  "value": 0
+                },
                 "use": "add_to_boil"
               }
             },
             {
               "name": "Nelson Sauvin",
-              "alpha_acid_units": 12,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 12
+              },
               "form": "pellet",
-              "beta_acid_units": 0,
+              "beta_acid": {
+                "unit": "%",
+                "value": 0
+              },
               "use": "boil",
-              "amount": { "unit": "kg", "value": 0.0125 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.0125
+              },
               "timing": {
-                "time": { "unit": "min", "value": 0 },
+                "time": {
+                  "unit": "min",
+                  "value": 0
+                },
                 "use": "add_to_boil"
               }
             },
             {
               "name": "Chinook",
-              "alpha_acid_units": 12.6,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 12.6
+              },
               "form": "pellet",
-              "beta_acid_units": 0,
+              "beta_acid": {
+                "unit": "%",
+                "value": 0
+              },
               "use": "dry hop",
-              "amount": { "unit": "kg", "value": 0.0475 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.0475
+              },
               "timing": {
-                "time": { "unit": "min", "value": 10080 },
+                "time": {
+                  "unit": "min",
+                  "value": 10080
+                },
                 "use": "add_to_boil"
               }
             },
             {
               "name": "Ahtanum",
-              "alpha_acid_units": 5.4,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 5.4
+              },
               "form": "pellet",
-              "beta_acid_units": 0,
+              "beta_acid": {
+                "unit": "%",
+                "value": 0
+              },
               "use": "dry hop",
-              "amount": { "unit": "kg", "value": 0.0375 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.0375
+              },
               "timing": {
-                "time": { "unit": "min", "value": 10080 },
+                "time": {
+                  "unit": "min",
+                  "value": 10080
+                },
                 "use": "add_to_boil"
               }
             },
             {
               "name": "Simcoe",
-              "alpha_acid_units": 12.8,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 12.8
+              },
               "form": "pellet",
-              "beta_acid_units": 0,
+              "beta_acid": {
+                "unit": "%",
+                "value": 0
+              },
               "use": "dry hop",
-              "amount": { "unit": "kg", "value": 0.0375 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.0375
+              },
               "timing": {
-                "time": { "unit": "min", "value": 10080 },
+                "time": {
+                  "unit": "min",
+                  "value": 10080
+                },
                 "use": "add_to_boil"
               }
             },
             {
               "name": "Nelson Sauvin",
-              "alpha_acid_units": 12,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 12
+              },
               "form": "pellet",
-              "beta_acid_units": 0,
+              "beta_acid": {
+                "unit": "%",
+                "value": 0
+              },
               "use": "dry hop",
-              "amount": { "unit": "kg", "value": 0.02 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.02
+              },
               "timing": {
-                "time": { "unit": "min", "value": 10080 },
+                "time": {
+                  "unit": "min",
+                  "value": 10080
+                },
                 "use": "add_to_boil"
               }
             },
             {
               "name": "Cascade",
-              "alpha_acid_units": 6.8,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 6.8
+              },
               "form": "pellet",
-              "beta_acid_units": 0,
+              "beta_acid": {
+                "unit": "%",
+                "value": 0
+              },
               "use": "dry hop",
-              "amount": { "unit": "kg", "value": 0.0375 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.0375
+              },
               "timing": {
-                "time": { "unit": "min", "value": 10080 },
+                "time": {
+                  "unit": "min",
+                  "value": 10080
+                },
                 "use": "add_to_boil"
               }
             },
             {
               "name": "Amarillo",
-              "alpha_acid_units": 8.9,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 8.9
+              },
               "form": "pellet",
-              "beta_acid_units": 0,
+              "beta_acid": {
+                "unit": "%",
+                "value": 0
+              },
               "use": "dry hop",
-              "amount": { "unit": "kg", "value": 0.01 },
+              "amount": {
+                "unit": "kg",
+                "value": 0.01
+              },
               "timing": {
-                "time": { "unit": "min", "value": 10080 },
+                "time": {
+                  "unit": "min",
+                  "value": 10080
+                },
                 "use": "add_to_boil"
               }
             }
@@ -206,19 +410,31 @@
               "name": "Wyeast 1056 - American Ale",
               "type": "ale",
               "form": "liquid",
-              "amount": { "unit": "l", "value": 0.035 }
+              "amount": {
+                "unit": "l",
+                "value": 0.035
+              }
             }
           ]
         },
         "mash": {
           "name": "Mash",
-          "grain_temperature": { "unit": "C", "value": 0 },
+          "grain_temperature": {
+            "unit": "C",
+            "value": 0
+          },
           "mash_steps": [
             {
               "name": "Mash step",
               "type": "temperature",
-              "step_temperature": { "unit": "C", "value": 66 },
-              "step_time": { "unit": "min", "value": 75 }
+              "step_temperature": {
+                "unit": "C",
+                "value": 66
+              },
+              "step_time": {
+                "unit": "min",
+                "value": 75
+              }
             }
           ]
         }

--- a/tests/generic/hop_varieties.json
+++ b/tests/generic/hop_varieties.json
@@ -5,7 +5,10 @@
       {
         "name": "name",
         "origin": "US",
-        "alpha_acid_units": 5
+        "alpha_acid": {
+          "unit": "%",
+          "value": 5
+        }
       }
     ]
   }

--- a/tests/generic/recipes.json
+++ b/tests/generic/recipes.json
@@ -54,8 +54,14 @@
               "name": "Citra",
               "origin": "US",
               "form": "pellet",
-              "alpha_acid_units": 10,
-              "beta_acid_units": 3,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 10
+              },
+              "beta_acid": {
+                "unit": "%",
+                "value": 3
+              },
               "type": "aroma/bittering",
               "notes": "American aroma hop Citra was created by John I. Haas, Inc. and Select Botanicals Group joint venture, the Hop Breeding Company. It was released to the brewing world in 2008.",
               "substitutes": "Simcoe®, Cascade (US), Centennial, Mosaic®",
@@ -79,7 +85,10 @@
               "name": "Distilled El Dorado Hop Oil",
               "origin": "US",
               "form": "extract",
-              "alpha_acid_units": 0,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 0
+              },
               "type": "aroma",
               "notes": "Distilled hop oil is an amazing new product we are making available to homebrewers.  Distilled hop oil varies from other oils in that it is produced from fresh hops, as opposed to dried and processed pellets.  Distilled hop oil delivers the same wet hop character that was previously only possible to acquire with the use of freshly harvested hops.  The oil is extremely shelf stable, so you can now brew a consistant fresh hop IPA all year long. Extremely volatile, this oil should only be used for aromatic applications; typically applied at bottling/kegging.",
               "use": "dry hop",

--- a/tests/real/BrettDosedKegsSaison.json
+++ b/tests/real/BrettDosedKegsSaison.json
@@ -82,7 +82,10 @@
             {
               "name": "EKG",
               "origin": "UK",
-              "alpha_acid_units": 5,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 5
+              },
               "amount": {
                 "unit": "oz",
                 "value": 1.15
@@ -98,7 +101,10 @@
             {
               "name": "EKG",
               "origin": "UK",
-              "alpha_acid_units": 5,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 5
+              },
               "amount": {
                 "unit": "oz",
                 "value": 0.6
@@ -114,7 +120,10 @@
             {
               "name": "EKG",
               "origin": "UK",
-              "alpha_acid_units": 5,
+              "alpha_acid": {
+                "unit": "%",
+                "value": 5
+              },
               "amount": {
                 "unit": "oz",
                 "value": 1

--- a/tests/real/HopRecordWithAllFields.json
+++ b/tests/real/HopRecordWithAllFields.json
@@ -6,8 +6,14 @@
         "name": "Super Hops",
         "origin": "Planet Krypton",
         "form": "leaf",
-        "alpha_acid_units": 4.5,
-        "beta_acid_units": 5.5,
+        "alpha_acid": {
+          "unit": "%",
+          "value": 4.5
+        },
+        "beta_acid": {
+          "unit": "%",
+          "value": 5.5
+        },
         "type": "bittering",
         "notes": "This hop is a really cool hops - you can use it for anything. It leaps over buildings in a single bound, is faster than a speeding bullet and makes really aromatic beers.",
         "percent_lost": {
@@ -30,8 +36,14 @@
         "name": "Lex Luthor Hops",
         "origin": "Planet Earth",
         "form": "extract",
-        "alpha_acid_units": 4.5,
-        "beta_acid_units": 5.5,
+        "alpha_acid": {
+          "unit": "%",
+          "value": 4.5
+        },
+        "beta_acid": {
+          "unit": "%",
+          "value": 5.5
+        },
         "type": "bittering",
         "notes": "This hop is a really dangerous hop - you can use it with extreme care. It cracks buildings in a single bound, is smarter than your average vilain, and makes really bitter beer.",
         "percent_lost": {

--- a/tests/real/HopWithRequiredFieldsOnly.json
+++ b/tests/real/HopWithRequiredFieldsOnly.json
@@ -5,7 +5,10 @@
       {
         "name": "Cascade",
         "origin": "US",
-        "alpha_acid_units": 5.5
+        "alpha_acid": {
+          "unit": "%",
+          "value": 5.5
+        }
       }
     ]
   }

--- a/types/flow-typed/beerjson.js
+++ b/types/flow-typed/beerjson.js
@@ -188,8 +188,8 @@ export type HopVarietyBase = {|
   name: string,
   origin?: string,
   form?: 'extract' | 'leaf' | 'leaf (wet)' | 'pellet' | 'powder' | 'plug',
-  alpha_acid_units: number,
-  beta_acid_units?: number
+  alpha_acid: PercentType,
+  beta_acid?: PercentType
 |}
 
 export type VarietyInformation = HopVarietyBase & {|

--- a/types/ts/beerjson.d.ts
+++ b/types/ts/beerjson.d.ts
@@ -187,8 +187,8 @@ declare namespace BeerJSON {
     name: string
     origin?: string
     form?: 'extract' | 'leaf' | 'leaf (wet)' | 'pellet' | 'powder' | 'plug'
-    alpha_acid_units: number
-    beta_acid_units?: number
+    alpha_acid: PercentType
+    beta_acid?: PercentType
   }
 
   export type VarietyInformation = HopVarietyBase & {


### PR DESCRIPTION
Use percent values for alfa and beta hop's acids. Rename to avoid intersection with term Alpha_Acid_Units http://brewwiki.com/index.php/Alpha_Acid_Units