### PR TITLE
Fix formatting for converted json files in tests

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,13 @@
 {
   "singleQuote": true,
   "semi": false,
-  "jsxBracketSameLine": true
+  "jsxBracketSameLine": true,
+    "overrides": [
+    {
+      "files": "*.json",
+      "options": {
+        "parser": "json-stringify"
+      }
+    }
+  ]
 }

--- a/tests/samples.test.js
+++ b/tests/samples.test.js
@@ -26,7 +26,7 @@ const convertFromXML = (dataDir, convertedDir) => {
   fs.readdirSync(dataDir).forEach(file => {
     const xmlString = fs.readFileSync(dataDir + file, 'utf8')
     const rawRecipe = importFromBeerXml(xmlString)
-    const recipe = prettier.format(rawRecipe, { parser: 'json' })
+    const recipe = prettier.format(rawRecipe, { parser: 'json-stringify' })
     fs.writeFileSync(convertedDir + file.replace('.xml', '.json'), recipe)
   })
 }


### PR DESCRIPTION
by default prettier uses "json" but should use "json-stringify".
This will fix diffs in tests for the converted files.