### PR TITLE
Added pressure to fermentation step

### DIFF
--- a/docs/fermentation_step.json.md
+++ b/docs/fermentation_step.json.md
@@ -19,4 +19,5 @@ FermentationStepType - a per step representation of a fermentation action.
 | **start_ph** |  | [AcidityType](measureable_units.json.md#aciditytype)|  |
 | **end_ph** |  | [AcidityType](measureable_units.json.md#aciditytype)|  |
 | **vessel** |  | string|  |
+| **vessel_pressure** |  | [PressureType](measureable_units.json.md#pressuretype)| Vessel pressure indicates the pressure applied within the fermentation vessel. |
 

--- a/docs/hop.json.md
+++ b/docs/hop.json.md
@@ -34,18 +34,18 @@ VarietyInformation collects the attributes of a hop variety to store as record i
 
 ## HopAdditionType 
 
-HopAdditionType collects the attributes of each hop ingredient for use in a recipe hop bil.
+HopAdditionType collects the attributes of each hop ingredient for use in a recipe hop bill.
 
 **HopAdditionType** is an object with all properties from [HopVarietyBase](#hopvarietybase) and these additional properties:
 
 |Name|Required|Type|Description|
 |--|--|--|--|
-| **timing** | ✅ | [TimingType](timing.json.md#timingtype)| The timing object fully describes the timing of an addition with options for basis on time, gravity, or pH at any process step. |
+| **timing** | ✅ | [TimingType](timing.json.md#timingtype)| The timing object fully describes the timing of an addition with options for a basis on time, gravity, or pH at any process step. |
 | **amount** | ✅ |  [VolumeType](measureable_units.json.md#volumetype) or  [MassType](measureable_units.json.md#masstype)|  |
 
 ## IBUEstimateType 
 
-Used to differentiate which IBU formula is being used in a recipe. If formula is modified in any way, eg to support whirlpool/flameout additions etc etc, please use `Other` for transparency.
+Used to differentiate the IBU formula used in a recipe. If the formula is modified in any way, e.g. to support whirlpool/flameout additions, then please use `Other` for transparency.
 
 **IBUEstimateType** is an object with these properties:
 

--- a/json/fermentation_step.json
+++ b/json/fermentation_step.json
@@ -42,6 +42,10 @@
         },
         "vessel": {
           "type": "string"
+        },
+        "vessel_pressure": {
+          "description": "Vessel pressure indicates the pressure applied within the fermentation vessel.",
+          "$ref": "measureable_units.json#/definitions/PressureType"
         }
       },
       "required": [

--- a/tests/generic/fermentation.json
+++ b/tests/generic/fermentation.json
@@ -34,6 +34,10 @@
             "step_time": {
               "unit": "day",
               "value": 10
+            },
+            "vessel_pressure": {
+              "unit": "psi",
+              "value": 5.5
             }
           },
           {

--- a/types/flow-typed/beerjson.js
+++ b/types/flow-typed/beerjson.js
@@ -209,7 +209,8 @@ export type FermentationStepType = {|
   end_gravity?: GravityType,
   start_ph?: AcidityType,
   end_ph?: AcidityType,
-  vessel?: string
+  vessel?: string,
+  vessel_pressure?: PressureType
 |}
 
 export type HopVarietyBase = {|

--- a/types/ts/beerjson.d.ts
+++ b/types/ts/beerjson.d.ts
@@ -209,6 +209,7 @@ declare namespace BeerJSON {
     start_ph?: AcidityType
     end_ph?: AcidityType
     vessel?: string
+    vessel_pressure?: PressureType
   }
 
   export type HopVarietyBase = {


### PR DESCRIPTION
Added `vessel_pressure` property to `FermentationStepType` to implement #178 for pressurised fermentation vessels.

Also included additional [hop.json.md](https://github.com/beerjson/beerjson/compare/master...johnjenkman:beerjson:pressure-fermentation-step#diff-117a255ba50c14ad5ac97cb9c62fbacce01cc9f7751f169e7d9b99128e5bf421) document update missed from #194.