### PR TITLE
Rename invalid "group" key in Fermentable to "grain_group"

### DIFF
--- a/js/beerxml-to-beerjson.js
+++ b/js/beerxml-to-beerjson.js
@@ -192,7 +192,7 @@ const fermentable_bill = r =>
     },
     origin: fermentable['ORIGIN'],
     supplier: fermentable['SUPPLIER'],
-    group: 'base',
+    grain_group: 'base',
     yield: {
       potential: {
         unit: 'sg',

--- a/tests/converted/GenericOneHF.json
+++ b/tests/converted/GenericOneHF.json
@@ -49,7 +49,7 @@
               },
               "origin": "Germany",
               "producer": "",
-              "group": "base",
+              "grain_group": "base",
               "yield": {
                 "potential": {
                   "unit": "sg",

--- a/tests/converted/Kolsh.json
+++ b/tests/converted/Kolsh.json
@@ -49,7 +49,7 @@
               },
               "origin": "Germany",
               "producer": "",
-              "group": "base",
+              "grain_group": "base",
               "yield": {
                 "potential": {
                   "unit": "sg",
@@ -71,7 +71,7 @@
               },
               "origin": "Germany",
               "producer": "",
-              "group": "base",
+              "grain_group": "base",
               "yield": {
                 "potential": {
                   "unit": "sg",
@@ -93,7 +93,7 @@
               },
               "origin": "US",
               "producer": "",
-              "group": "base",
+              "grain_group": "base",
               "yield": {
                 "potential": {
                   "unit": "sg",

--- a/tests/converted/Londonpride.json
+++ b/tests/converted/Londonpride.json
@@ -46,7 +46,7 @@
                 "value": 9
               },
               "origin": "United Kingdom",
-              "group": "base",
+              "grain_group": "base",
               "yield": {
                 "potential": {
                   "unit": "sg",
@@ -67,7 +67,7 @@
                 "value": 0.6
               },
               "origin": "Finland",
-              "group": "base",
+              "grain_group": "base",
               "yield": {
                 "potential": {
                   "unit": "sg",

--- a/tests/converted/RRSummerBitter.json
+++ b/tests/converted/RRSummerBitter.json
@@ -48,7 +48,7 @@
               },
               "origin": "United Kingdom",
               "producer": "Maris Otter",
-              "group": "base",
+              "grain_group": "base",
               "yield": {
                 "potential": {
                   "unit": "sg",
@@ -70,7 +70,7 @@
               },
               "origin": "Belgium",
               "producer": "",
-              "group": "base",
+              "grain_group": "base",
               "yield": {
                 "potential": {
                   "unit": "sg",

--- a/tests/converted/punk-ipa-2010-current.json
+++ b/tests/converted/punk-ipa-2010-current.json
@@ -39,7 +39,7 @@
                 "unit": "kg",
                 "value": 4.38
               },
-              "group": "base",
+              "grain_group": "base",
               "yield": {
                 "potential": {
                   "unit": "sg",
@@ -58,7 +58,7 @@
                 "unit": "kg",
                 "value": 0.25
               },
-              "group": "base",
+              "grain_group": "base",
               "yield": {
                 "potential": {
                   "unit": "sg",


### PR DESCRIPTION
"group" doesn't seem to exist in the Fermentable type.