### PR TITLE
Fix two JSON Schema authoring issues (packaging_vessel.graphics, misc.json root)

### DIFF
--- a/json/misc.json
+++ b/json/misc.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/beerjson/beerjson/master/json/misc.json",
   "type": "object",
+  "additionalProperties": false,
   "definitions": {
     "MiscellaneousBase": {
       "type": "object",

--- a/json/packaging_vessel.json
+++ b/json/packaging_vessel.json
@@ -61,7 +61,9 @@
         },
         "graphics": {
           "type": "array",
-          "$ref": "packaging_graphic.json#/definitions/PackagingGraphicType"
+          "items": {
+            "$ref": "packaging_graphic.json#/definitions/PackagingGraphicType"
+          }
         }
       },
       "required": [


### PR DESCRIPTION
## Summary

Two small schema authoring fixes audited together. Each is a single-line change with zero compat cost.

### 1. `packaging_vessel.json` — wrap `graphics` `$ref` in `items:`

`PackagingVesselType.graphics` has both `type: "array"` and `$ref` as direct keywords:

```json
"graphics": {
  "type": "array",
  "$ref": "packaging_graphic.json#/definitions/PackagingGraphicType"
}
```

Per JSON Schema draft-07, sibling keywords of `\$ref` MUST be ignored. That means:

- **ajv** silently drops `type: array` and treats `graphics` as a single `PackagingGraphicType` object — which contradicts both the field name and the obvious author intent (a list of graphics on the vessel).
- **Stricter validators** (`typify`, the `jsonschema` Rust crate) reject the schema outright as ambiguous.

Wrap the `$ref` in `items:` so the schema validates the same way across every JSON Schema validator:

```json
"graphics": {
  "type": "array",
  "items": {
    "$ref": "packaging_graphic.json#/definitions/PackagingGraphicType"
  }
}
```

### 2. `misc.json` — add root-level `additionalProperties: false`

Every other schema file in `json/` closes its root with `additionalProperties: false`. `misc.json` was the only one missing it. Pure consistency.

## Compatibility

- No data files in the repo exercise `packaging_vessel.graphics`, so the array wrapper is zero-compat-cost. ajv's effective behaviour on the old shape (single object) was almost certainly never what producers were emitting — anyone using the field today is most likely already emitting an array, so this strictly improves their validation.
- The `misc.json` change touches only the root container, never the validated `definitions/*` subschemas, so it has no observable behaviour change.
