### PR TITLE
Add value to IBU estimate

### DIFF
--- a/docs/hop.json.md
+++ b/docs/hop.json.md
@@ -45,13 +45,14 @@ HopAdditionType collects the attributes of each hop ingredient for use in a reci
 
 ## IBUEstimateType 
 
-Used to differentiate the IBU formula used in a recipe. If the formula is modified in any way, e.g. to support whirlpool/flameout additions, then please use `Other` for transparency.
+Stores the IBU formula used in a recipe and, when available, the resulting estimated bitterness. If the formula is modified in any way, e.g. to support whirlpool/flameout additions, then please use `Other` for transparency.
 
 **IBUEstimateType** is an object with these properties:
 
 |Name|Required|Type|Description|
 |--|--|--|--|
 | **method** |  | [IBUMethodType](#ibumethodtype)|  |
+| **value** |  | [BitternessType](measureable_units.json.md#bitternesstype)|  |
 
 ## IBUMethodType 
 

--- a/docs/recipe.json.md
+++ b/docs/recipe.json.md
@@ -22,7 +22,7 @@ RecipeType composes the information stored in a beerjson recipe.
 | **original_gravity** |  | [GravityType](measureable_units.json.md#gravitytype)| The gravity of wort when transffered to the fermenter. |
 | **final_gravity** |  | [GravityType](measureable_units.json.md#gravitytype)| The gravity of beer at the end of fermentation. |
 | **alcohol_by_volume** |  | [PercentType](measureable_units.json.md#percenttype)|  |
-| **ibu_estimate** |  | [IBUEstimateType](hop.json.md#ibuestimatetype)| Used to differentiate which IBU formula is being used in a recipe. If formula is modified in any way, eg to support whirlpool/flameout additions etc etc, please use `Other` for transparency. |
+| **ibu_estimate** |  | [IBUEstimateType](hop.json.md#ibuestimatetype)| The estimated bitterness of the finished beer together with the IBU formula used to calculate it. If the formula is modified in any way, e.g. to support whirlpool/flameout additions, please use `Other` for transparency. |
 | **color_estimate** |  | [ColorType](measureable_units.json.md#colortype)| The color of the finished beer, using SRM or EBC. |
 | **beer_pH** |  | [AcidityType](measureable_units.json.md#aciditytype)| The final beer pH at the end of fermentation. |
 | **carbonation** |  | number| The final carbonation of the beer when packaged or served. |

--- a/js/ibu-estimate.test.js
+++ b/js/ibu-estimate.test.js
@@ -1,0 +1,9 @@
+const hopSchema = require('../json/hop')
+
+describe('IBUEstimateType', () => {
+  test('references the shared bitterness measurement type for its value', () => {
+    expect(hopSchema.definitions.IBUEstimateType.properties.value).toEqual({
+      $ref: 'measureable_units.json#/definitions/BitternessType'
+    })
+  })
+})

--- a/json/hop.json
+++ b/json/hop.json
@@ -120,11 +120,14 @@
       ]
     },
     "IBUEstimateType": {
-      "description": "Used to differentiate the IBU formula used in a recipe. If the formula is modified in any way, e.g. to support whirlpool/flameout additions, then please use `Other` for transparency.",
+      "description": "Stores the IBU formula used in a recipe and, when available, the resulting estimated bitterness. If the formula is modified in any way, e.g. to support whirlpool/flameout additions, then please use `Other` for transparency.",
       "type": "object",
       "properties": {
         "method": {
           "$ref": "#/definitions/IBUMethodType"
+        },
+        "value": {
+          "$ref": "measureable_units.json#/definitions/BitternessType"
         }
       }
     },

--- a/json/recipe.json
+++ b/json/recipe.json
@@ -69,7 +69,7 @@
           "$ref": "measureable_units.json#/definitions/PercentType"
         },
         "ibu_estimate": {
-          "description": "Used to differentiate which IBU formula is being used in a recipe. If formula is modified in any way, eg to support whirlpool/flameout additions etc etc, please use `Other` for transparency.",
+          "description": "The estimated bitterness of the finished beer together with the IBU formula used to calculate it. If the formula is modified in any way, e.g. to support whirlpool/flameout additions, please use `Other` for transparency.",
           "$ref": "hop.json#/definitions/IBUEstimateType"
         },
         "color_estimate": {

--- a/tests/generic/recipes.json
+++ b/tests/generic/recipes.json
@@ -216,6 +216,13 @@
             "value": 60
           }
         },
+        "ibu_estimate": {
+          "method": "Tinseth",
+          "value": {
+            "unit": "IBUs",
+            "value": 35
+          }
+        },
         "fermentation": {
           "name": "Ale, Single Stage",
           "description": "A simple single stage fermentation, often used by extract brewers or for classic ales.",

--- a/types/flow-typed/beerjson.js
+++ b/types/flow-typed/beerjson.js
@@ -246,7 +246,8 @@ export type HopAdditionType = HopVarietyBase & {|
 |}
 
 export type IBUEstimateType = {|
-  method?: IBUMethodType
+  method?: IBUMethodType,
+  value?: BitternessType
 |}
 
 export type IBUMethodType = 'Rager' | 'Tinseth' | 'Garetz' | 'Other'

--- a/types/ts/beerjson.d.ts
+++ b/types/ts/beerjson.d.ts
@@ -246,6 +246,7 @@ declare namespace BeerJSON {
 
   export type IBUEstimateType = {
     method?: IBUMethodType
+    value?: BitternessType
   }
 
   export type IBUMethodType = 'Rager' | 'Tinseth' | 'Garetz' | 'Other'


### PR DESCRIPTION
## Summary
- extend `IBUEstimateType` with an optional `value` using the shared `BitternessType`
- preserve compatibility with existing BeerJSON 1.x documents that only specify `method`
- add a representative Tinseth/35 IBU recipe example
- update generated Markdown, TypeScript and Flow artifacts
- add a focused schema contract test

## Compatibility

`value` is intentionally optional. Existing documents such as:

```json
{
  "ibu_estimate": {
    "method": "Tinseth"
  }
}
```

remain valid, while producers can now keep the calculated estimate and its method together:

```json
{
  "ibu_estimate": {
    "method": "Tinseth",
    "value": {
      "unit": "IBUs",
      "value": 35
    }
  }
}
```

The existing BeerXML XSD already models an IBU estimate as a decimal value with a method attribute, so no XSD change is needed.

## Verification
- [x] 5 Jest suites passed
- [x] 64 tests passed
- [x] 13 snapshots passed
- [x] existing method-only fixtures remain valid
- [x] representative method+value fixture validates
- [x] generated Markdown, TypeScript and Flow artifacts agree with the schema
- [x] Prettier and `git diff --check` passed
- [x] independent exact-tree review passed without findings

Closes #223