### PR TITLE
Close 9 of 13 allOf types to unknown keys, and fix the BeerXML importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,14 @@ release. The npm package is still 1.0.2, so none of it has reached consumers.
   a message and ajv's params.
 - **`engines: node >= 22`** declared, and CI runs the suite on Node 22 and 24
   ([#216](https://github.com/beerjson/beerjson/issues/216)).
+- **Nine of the thirteen `allOf`-composed types now reject unknown keys**, via
+  2020-12's `unevaluatedProperties`: `CultureInformation`,
+  `CultureAdditionType`, `EquipmentItemType`, `FermentableType`,
+  `FermentableAdditionType`, `VarietyInformation`, `MiscellaneousType`,
+  `MiscellaneousAdditionType` and `WaterType`. A misspelled key in any of them
+  was previously accepted and silently discarded, and draft-07 offered no way to
+  catch it. `HopAdditionType`, `WaterAdditionType`, `StyleType` and
+  `RecipeStyleType` remain open pending format questions.
 
 ### Fixed
 
@@ -78,6 +86,21 @@ release. The npm package is still 1.0.2, so none of it has reached consumers.
   they still declared the removed `DensityUnitType`, and `BeerJSON.profiles` was
   typed `WaterBase[]` where the schema says `WaterType`. All four are corrected
   by regenerating.
+- **The BeerXML importer converted every hop as a boil addition**, because
+  `timing.use` was hardcoded to `add_to_boil` while BeerXML's `USE` was written
+  out to a `use` key the format does not have. Dry hops therefore became boil
+  additions. `USE` is now mapped to `timing.use`, so the six dry hop additions
+  in the fixtures convert to `add_to_fermentation`. Same fix for miscellaneous
+  additions.
+- **The BeerXML importer emitted three more keys the format does not have**:
+  `supplier` on fermentable additions (the schema calls it `producer`),
+  `add_after_boil` (now a `timing` of `add_to_fermentation`), and `use` on
+  miscellaneous additions. Its `parseBool` also only recognised uppercase
+  `TRUE`, so a lowercase `true` in a source file read as false.
+- **Test fixtures used properties the format does not have**: `laboratory` for
+  `producer` on cultures, `add_to_fermentation_step: N` where `TimingType`
+  expresses exactly that as `timing.step`, and the hop oil fields flat on an
+  addition rather than nested under `oil_content`.
 - **`packaging_vessel.graphics` and the `misc.json` root** had JSON Schema
   authoring errors ([#222](https://github.com/beerjson/beerjson/pull/222)).
 - **Kolbach Index** is a percentage, and is now typed as one

--- a/SCHEMA_STYLE.md
+++ b/SCHEMA_STYLE.md
@@ -112,9 +112,12 @@ sees the whole composition:
 Putting either keyword on `CultureBase` would reject every property
 `CultureAdditionType` adds.
 
-The composed types do not carry `unevaluatedProperties` yet: enabling it rejects
-59 keys currently present in the repository's own test corpus. Adding it to a
-type is therefore a change that comes with fixing that type's examples.
+Nine of the thirteen composed types carry it. The four that do not
+(`HopAdditionType`, `WaterAdditionType`, `StyleType`, `RecipeStyleType`) are
+blocked on open format questions: their own examples under `tests/` use
+properties the types do not declare. Closing one is therefore a change that
+comes with resolving that question and fixing its examples. The conventions test
+tracks the four, so a newly added composed type cannot join them.
 
 ## Arrays
 

--- a/js/beerxml-to-beerjson.js
+++ b/js/beerxml-to-beerjson.js
@@ -9,7 +9,7 @@ const {
   lowerCase
 } = require('lodash')
 
-const parseBool = s => s === 'TRUE'
+const parseBool = s => String(s).toUpperCase() === 'TRUE'
 const getArrayNode = node =>
   Array.from(isNil(node) ? [] : Array.isArray(node) ? node : [node])
 
@@ -28,6 +28,22 @@ const getFermentableType = type =>
   ].indexOf(type) == -1
     ? 'other'
     : type
+
+// BeerXML records when an ingredient is added as a free-text USE on the
+// ingredient; BeerJSON records it as `timing.use`. Values not listed here (and
+// a missing USE) fall back to the boil, which is where BeerXML puts an
+// unqualified addition.
+const USE_TO_TIMING = {
+  boil: 'add_to_boil',
+  'first wort': 'add_to_boil',
+  aroma: 'add_to_boil',
+  mash: 'add_to_mash',
+  'dry hop': 'add_to_fermentation',
+  primary: 'add_to_fermentation',
+  secondary: 'add_to_fermentation',
+  bottling: 'add_to_package'
+}
+const timingUse = use => USE_TO_TIMING[lowerCase(use)] || 'add_to_boil'
 
 const potential = y => (y * 0.46) / 1000 + 1
 const mash_steps = r =>
@@ -118,7 +134,6 @@ const miscellaneous_additions = r =>
   map(getArrayNode(get(r, ['MISCS', 'MISC'])), misc => ({
     name: misc['NAME'],
     type: lowerCase(misc['TYPE']),
-    use: lowerCase(misc['USE']),
     ...(!isEmpty(misc['AMOUNT_IS_WEIGHT']) &&
     parseBool(misc['AMOUNT_IS_WEIGHT'])
       ? {
@@ -143,7 +158,7 @@ const miscellaneous_additions = r =>
         unit: 'min',
         value: Number(misc['TIME'])
       },
-      use: 'add_to_boil'
+      use: timingUse(misc['USE'])
     }
   }))
 
@@ -164,7 +179,6 @@ const hop_bill = r =>
           }
         }
       : {}),
-    ...(!isEmpty(hop['USE']) ? { use: lowerCase(hop['USE']) } : {}),
     amount: {
       unit: 'kg',
       value: Number(hop['AMOUNT'])
@@ -174,7 +188,7 @@ const hop_bill = r =>
         unit: 'min',
         value: Number(hop['TIME'])
       },
-      use: 'add_to_boil'
+      use: timingUse(hop['USE'])
     }
   }))
 
@@ -191,7 +205,7 @@ const fermentable_bill = r =>
       value: Number(fermentable['AMOUNT'])
     },
     origin: fermentable['ORIGIN'],
-    supplier: fermentable['SUPPLIER'],
+    producer: fermentable['SUPPLIER'],
     grain_group: 'base',
     yield: {
       potential: {
@@ -199,9 +213,13 @@ const fermentable_bill = r =>
         value: potential(Number(fermentable['YIELD']))
       }
     },
-    ...(!isEmpty(fermentable['ADD_AFTER_BOIL'])
+    // BeerXML's ADD_AFTER_BOIL boolean has no direct BeerJSON equivalent; a
+    // fermentable added after the boil is one added to the fermentation.
+    ...(parseBool(fermentable['ADD_AFTER_BOIL'])
       ? {
-          add_after_boil: parseBool(fermentable['ADD_AFTER_BOIL'])
+          timing: {
+            use: 'add_to_fermentation'
+          }
         }
       : {})
   }))

--- a/json/culture.json
+++ b/json/culture.json
@@ -55,6 +55,7 @@
     "CultureInformation": {
       "type": "object",
       "description": "CultureInformation collects the attributes of a microbial culture.",
+      "unevaluatedProperties": false,
       "allOf": [
         {
           "$ref": "#/$defs/CultureBase"
@@ -108,6 +109,7 @@
     "CultureAdditionType": {
       "type": "object",
       "description": "CultureAdditionType collects the attributes of each culture ingredient for use in a recipe.",
+      "unevaluatedProperties": false,
       "allOf": [
         {
           "$ref": "#/$defs/CultureBase"

--- a/json/equipment.json
+++ b/json/equipment.json
@@ -39,6 +39,7 @@
     "EquipmentItemType": {
       "type": "object",
       "description": "EquipmentType provides necessary information for individual brewing equipment.",
+      "unevaluatedProperties": false,
       "allOf": [
         {
           "$ref": "#/$defs/EquipmentBase"

--- a/json/fermentable.json
+++ b/json/fermentable.json
@@ -62,6 +62,7 @@
     "FermentableType": {
       "type": "object",
       "description": "FermentableType collects the attributes of a fermentable ingredient to store as record information.",
+      "unevaluatedProperties": false,
       "allOf": [
         {
           "$ref": "#/$defs/FermentableBase"
@@ -155,6 +156,7 @@
     "FermentableAdditionType": {
       "type": "object",
       "description": "FermentableAdditionType collects the attributes of each fermentable ingredient for use in a recipe fermentable bill.",
+      "unevaluatedProperties": false,
       "allOf": [
         {
           "$ref": "#/$defs/FermentableBase"

--- a/json/hop.json
+++ b/json/hop.json
@@ -49,6 +49,7 @@
     "VarietyInformation": {
       "type": "object",
       "description": "VarietyInformation collects the attributes of a hop variety to store as record information.",
+      "unevaluatedProperties": false,
       "allOf": [
         {
           "$ref": "#/$defs/HopVarietyBase"

--- a/json/misc.json
+++ b/json/misc.json
@@ -38,6 +38,7 @@
     "MiscellaneousType": {
       "type": "object",
       "description": "MiscellaneousType collects the attributes of an ingredient to store as record information.",
+      "unevaluatedProperties": false,
       "allOf": [
         {
           "$ref": "#/$defs/MiscellaneousBase"
@@ -61,6 +62,7 @@
     "MiscellaneousAdditionType": {
       "type": "object",
       "description": "MiscellaneousAdditionType collects the attributes of each miscellaneous ingredient for use in a recipe.",
+      "unevaluatedProperties": false,
       "allOf": [
         {
           "$ref": "#/$defs/MiscellaneousBase"

--- a/json/water.json
+++ b/json/water.json
@@ -64,6 +64,7 @@
     "WaterType": {
       "type": "object",
       "description": "WaterType collects the attributes of a brewing water to store as record information",
+      "unevaluatedProperties": false,
       "allOf": [
         {
           "$ref": "#/$defs/WaterBase"

--- a/tests/converted/GenericOneHF.json
+++ b/tests/converted/GenericOneHF.json
@@ -42,15 +42,14 @@
                 "value": 3.2412931
               },
               "origin": "Germany",
-              "supplier": "",
+              "producer": "",
               "grain_group": "base",
               "yield": {
                 "potential": {
                   "unit": "sg",
                   "value": 1.03726
                 }
-              },
-              "add_after_boil": false
+              }
             }
           ],
           "hop_additions": [
@@ -66,7 +65,6 @@
                 "unit": "%",
                 "value": 4
               },
-              "use": "boil",
               "amount": {
                 "unit": "kg",
                 "value": 0.0332677
@@ -84,7 +82,6 @@
             {
               "name": "Whirlfloc Tablet",
               "type": "fining",
-              "use": "boil",
               "amount": {
                 "unit": "l",
                 "value": 0.412685

--- a/tests/converted/Kolsh.json
+++ b/tests/converted/Kolsh.json
@@ -42,15 +42,14 @@
                 "value": 3.2412931
               },
               "origin": "Germany",
-              "supplier": "",
+              "producer": "",
               "grain_group": "base",
               "yield": {
                 "potential": {
                   "unit": "sg",
                   "value": 1.03726
                 }
-              },
-              "add_after_boil": false
+              }
             },
             {
               "name": "Vienna Malt",
@@ -64,15 +63,14 @@
                 "value": 0.8640194
               },
               "origin": "Germany",
-              "supplier": "",
+              "producer": "",
               "grain_group": "base",
               "yield": {
                 "potential": {
                   "unit": "sg",
                   "value": 1.03588
                 }
-              },
-              "add_after_boil": false
+              }
             },
             {
               "name": "Cara-Pils/Dextrine",
@@ -86,15 +84,14 @@
                 "value": 0.2164116
               },
               "origin": "US",
-              "supplier": "",
+              "producer": "",
               "grain_group": "base",
               "yield": {
                 "potential": {
                   "unit": "sg",
                   "value": 1.03312
                 }
-              },
-              "add_after_boil": false
+              }
             }
           ],
           "hop_additions": [
@@ -110,7 +107,6 @@
                 "unit": "%",
                 "value": 4
               },
-              "use": "boil",
               "amount": {
                 "unit": "kg",
                 "value": 0.0332677
@@ -135,7 +131,6 @@
                 "unit": "%",
                 "value": 4
               },
-              "use": "boil",
               "amount": {
                 "unit": "kg",
                 "value": 0.0166339
@@ -153,7 +148,6 @@
             {
               "name": "Whirlfloc Tablet",
               "type": "fining",
-              "use": "boil",
               "amount": {
                 "unit": "l",
                 "value": 0.412685

--- a/tests/converted/Londonpride.json
+++ b/tests/converted/Londonpride.json
@@ -46,8 +46,7 @@
                   "unit": "sg",
                   "value": 1.0380006
                 }
-              },
-              "add_after_boil": false
+              }
             },
             {
               "name": "Cara Plus 200",
@@ -67,8 +66,7 @@
                   "unit": "sg",
                   "value": 1.0350014
                 }
-              },
-              "add_after_boil": false
+              }
             }
           ],
           "hop_additions": [
@@ -79,7 +77,6 @@
                 "value": 11.5
               },
               "form": "pellet",
-              "use": "boil",
               "amount": {
                 "unit": "kg",
                 "value": 0.03
@@ -99,7 +96,6 @@
                 "value": 11.5
               },
               "form": "pellet",
-              "use": "boil",
               "amount": {
                 "unit": "kg",
                 "value": 0.03

--- a/tests/converted/RRSummerBitter.json
+++ b/tests/converted/RRSummerBitter.json
@@ -41,15 +41,14 @@
                 "value": 6.9999955
               },
               "origin": "United Kingdom",
-              "supplier": "Maris Otter",
+              "producer": "Maris Otter",
               "grain_group": "base",
               "yield": {
                 "potential": {
                   "unit": "sg",
                   "value": 1.03795
                 }
-              },
-              "add_after_boil": false
+              }
             },
             {
               "name": "Cara 50",
@@ -63,15 +62,14 @@
                 "value": 0.9999994
               },
               "origin": "Belgium",
-              "supplier": "",
+              "producer": "",
               "grain_group": "base",
               "yield": {
                 "potential": {
                   "unit": "sg",
                   "value": 1.0345
                 }
-              },
-              "add_after_boil": false
+              }
             }
           ],
           "hop_additions": [
@@ -87,7 +85,6 @@
                 "unit": "%",
                 "value": 5
               },
-              "use": "boil",
               "amount": {
                 "unit": "kg",
                 "value": 0.04
@@ -112,7 +109,6 @@
                 "unit": "%",
                 "value": 3.5
               },
-              "use": "boil",
               "amount": {
                 "unit": "kg",
                 "value": 0.015
@@ -137,7 +133,6 @@
                 "unit": "%",
                 "value": 3.5
               },
-              "use": "boil",
               "amount": {
                 "unit": "kg",
                 "value": 0.015

--- a/tests/converted/punk-ipa-2010-current.json
+++ b/tests/converted/punk-ipa-2010-current.json
@@ -79,7 +79,6 @@
                 "unit": "%",
                 "value": 0
               },
-              "use": "boil",
               "amount": {
                 "unit": "kg",
                 "value": 0.02
@@ -103,7 +102,6 @@
                 "unit": "%",
                 "value": 0
               },
-              "use": "boil",
               "amount": {
                 "unit": "kg",
                 "value": 0.0125
@@ -127,7 +125,6 @@
                 "unit": "%",
                 "value": 0
               },
-              "use": "boil",
               "amount": {
                 "unit": "kg",
                 "value": 0.02
@@ -151,7 +148,6 @@
                 "unit": "%",
                 "value": 0
               },
-              "use": "boil",
               "amount": {
                 "unit": "kg",
                 "value": 0.0125
@@ -175,7 +171,6 @@
                 "unit": "%",
                 "value": 0
               },
-              "use": "boil",
               "amount": {
                 "unit": "kg",
                 "value": 0.0275
@@ -199,7 +194,6 @@
                 "unit": "%",
                 "value": 0
               },
-              "use": "boil",
               "amount": {
                 "unit": "kg",
                 "value": 0.0125
@@ -223,7 +217,6 @@
                 "unit": "%",
                 "value": 0
               },
-              "use": "boil",
               "amount": {
                 "unit": "kg",
                 "value": 0.0125
@@ -247,7 +240,6 @@
                 "unit": "%",
                 "value": 0
               },
-              "use": "boil",
               "amount": {
                 "unit": "kg",
                 "value": 0.0125
@@ -271,7 +263,6 @@
                 "unit": "%",
                 "value": 0
               },
-              "use": "dry hop",
               "amount": {
                 "unit": "kg",
                 "value": 0.0475
@@ -281,7 +272,7 @@
                   "unit": "min",
                   "value": 10080
                 },
-                "use": "add_to_boil"
+                "use": "add_to_fermentation"
               }
             },
             {
@@ -295,7 +286,6 @@
                 "unit": "%",
                 "value": 0
               },
-              "use": "dry hop",
               "amount": {
                 "unit": "kg",
                 "value": 0.0375
@@ -305,7 +295,7 @@
                   "unit": "min",
                   "value": 10080
                 },
-                "use": "add_to_boil"
+                "use": "add_to_fermentation"
               }
             },
             {
@@ -319,7 +309,6 @@
                 "unit": "%",
                 "value": 0
               },
-              "use": "dry hop",
               "amount": {
                 "unit": "kg",
                 "value": 0.0375
@@ -329,7 +318,7 @@
                   "unit": "min",
                   "value": 10080
                 },
-                "use": "add_to_boil"
+                "use": "add_to_fermentation"
               }
             },
             {
@@ -343,7 +332,6 @@
                 "unit": "%",
                 "value": 0
               },
-              "use": "dry hop",
               "amount": {
                 "unit": "kg",
                 "value": 0.02
@@ -353,7 +341,7 @@
                   "unit": "min",
                   "value": 10080
                 },
-                "use": "add_to_boil"
+                "use": "add_to_fermentation"
               }
             },
             {
@@ -367,7 +355,6 @@
                 "unit": "%",
                 "value": 0
               },
-              "use": "dry hop",
               "amount": {
                 "unit": "kg",
                 "value": 0.0375
@@ -377,7 +364,7 @@
                   "unit": "min",
                   "value": 10080
                 },
-                "use": "add_to_boil"
+                "use": "add_to_fermentation"
               }
             },
             {
@@ -391,7 +378,6 @@
                 "unit": "%",
                 "value": 0
               },
-              "use": "dry hop",
               "amount": {
                 "unit": "kg",
                 "value": 0.01
@@ -401,7 +387,7 @@
                   "unit": "min",
                   "value": 10080
                 },
-                "use": "add_to_boil"
+                "use": "add_to_fermentation"
               }
             }
           ],

--- a/tests/generic/cultures.json
+++ b/tests/generic/cultures.json
@@ -6,7 +6,7 @@
         "name": "Ole English Ale Yeast",
         "type": "ale",
         "form": "liquid",
-        "laboratory": "",
+        "producer": "",
         "product_id": ""
       }
     ]

--- a/tests/generic/recipes.json
+++ b/tests/generic/recipes.json
@@ -65,10 +65,6 @@
               "type": "aroma/bittering",
               "notes": "American aroma hop Citra was created by John I. Haas, Inc. and Select Botanicals Group joint venture, the Hop Breeding Company. It was released to the brewing world in 2008.",
               "substitutes": "Simcoe®, Cascade (US), Centennial, Mosaic®",
-              "humulene": 12,
-              "caryophyllene": 8,
-              "myrcene": 60,
-              "farnesene": 1,
               "inventory": {
                 "pellet": {
                   "unit": "g",
@@ -85,6 +81,12 @@
                   "value": 2
                 },
                 "use": "add_to_fermentation"
+              },
+              "oil_content": {
+                "myrcene": 60,
+                "humulene": 12,
+                "caryophyllene": 8,
+                "farnesene": 1
               }
             },
             {
@@ -116,36 +118,45 @@
               "name": "Burlington Ale",
               "type": "ale",
               "form": "liquid",
-              "laboratory": "White Labs",
+              "producer": "White Labs",
               "product_id": "WLP095",
-              "add_to_fermentation_step": 1,
               "amount": {
                 "unit": "ml",
                 "value": 40
+              },
+              "timing": {
+                "use": "add_to_fermentation",
+                "step": 1
               }
             },
             {
               "name": "California Ale Yeast",
               "type": "ale",
               "form": "liquid",
-              "laboratory": "White Labs",
+              "producer": "White Labs",
               "product_id": "WLP001",
-              "add_to_fermentation_step": 2,
               "amount": {
                 "unit": "each",
                 "value": 1
+              },
+              "timing": {
+                "use": "add_to_fermentation",
+                "step": 2
               }
             },
             {
               "name": "US-05",
               "type": "ale",
               "form": "dry",
-              "laboratory": "Safale",
+              "producer": "Safale",
               "product_id": "WLP001",
-              "add_to_fermentation_step": 3,
               "amount": {
                 "unit": "g",
                 "value": 11.5
+              },
+              "timing": {
+                "use": "add_to_fermentation",
+                "step": 3
               }
             }
           ],

--- a/tests/schema-conventions.test.js
+++ b/tests/schema-conventions.test.js
@@ -224,6 +224,30 @@ describe('objects and composition', () => {
     expect(found).toEqual([])
   })
 
+  // A composed type without unevaluatedProperties accepts any misspelled key,
+  // because additionalProperties cannot do the job next to an allOf. The four
+  // still open are blocked on format questions, not on effort: their own
+  // examples under tests/ use properties the types do not declare.
+  test('allOf compositions are closed to unknown keys', () => {
+    const found = []
+    for (const file of files) {
+      for (const [name, def] of Object.entries(schemas[file].$defs || {})) {
+        if (!def.allOf) continue
+        if (!('unevaluatedProperties' in def)) found.push(`${file}#${name}`)
+      }
+    }
+    expectOnlyKnown(found, [
+      // Recipe examples put the full variety record on an addition.
+      'hop.json#HopAdditionType',
+      // The BeerXML importer fills these with the style's ranges.
+      'style.json#RecipeStyleType',
+      // The BJCP and BA style guides carry 38 keys the type does not declare.
+      'style.json#StyleType',
+      // A recipe example records the pH of the water it added.
+      'water.json#WaterAdditionType'
+    ])
+  })
+
   // unevaluatedProperties belongs on the outermost composed type only. On a
   // base it would reject every property the extension adds.
   test('unevaluatedProperties is not declared on an allOf base', () => {


### PR DESCRIPTION
## Summary

Third of the stack, after #240 and #244. One commit, and the one with the most real change to how documents validate, so worth a closer look than the previous two.

Now that #240 put the schemas on 2020-12, `unevaluatedProperties: false` can close an `allOf`-composed type to unknown keys. This turns it on for **9 of the 13** composed types, and fixes the bugs that were blocking them.

## Why this matters

In draft-07 there was no way to do this. `additionalProperties: false` next to an `allOf` only sees properties declared in the same schema object, so it rejects everything the other branch contributes:

```
draft-07, additionalProperties: false on CultureAdditionType
  a valid document  ->  REJECTED: must NOT have additional properties
                        {"additionalProperty":"name"}
```

Which is why those 13 types declare nothing, and why every `*AdditionType`, `*Information` and `WaterType` has silently accepted and discarded **any** misspelled key for the life of the format. Write `nmae` instead of `name` on a culture addition and it validates today.

Turning the keyword on surfaced **59 distinct invalid keys across 3,240 places** in the documents under `tests/`. Those documents were always wrong. Nothing could tell.

## Bugs this fixes in our own BeerXML importer

**Every hop was converted as a boil addition.** `timing.use` was hardcoded to `add_to_boil`, while BeerXML's `USE` was written out to a `use` key the format does not have. So the invalid key was the only record that a dry hop was a dry hop, and any consumer reading the converted output saw a boil addition. `USE` now maps to `timing.use`:

```
punk-ipa-2010-current.json, after:
  Chinook         add_to_boil
  Ahtanum         add_to_boil
  ...
  Chinook         add_to_fermentation   <- was add_to_boil
  Ahtanum         add_to_fermentation   <- was add_to_boil
  Simcoe          add_to_fermentation   <- was add_to_boil
  Nelson Sauvin   add_to_fermentation   <- was add_to_boil
  Cascade         add_to_fermentation   <- was add_to_boil
  Amarillo        add_to_fermentation   <- was add_to_boil
```

Six additions in the fixtures were being misconverted. Same fix applied to miscellaneous additions.

Also in the importer:

- `supplier` on fermentable additions: the schema calls it `producer`.
- `add_after_boil`: BeerXML's boolean has no BeerJSON equivalent, so it becomes a `timing` of `add_to_fermentation`.
- `parseBool` only matched uppercase `TRUE`, so a lowercase `true` in a source file read as `false`.

## Fixes in the test fixtures

- `laboratory` is the BeerXML 1.0 name for what the schema calls `producer`.
- `add_to_fermentation_step: 2` is precisely what `TimingType` already describes as `{ use: "add_to_fermentation", step: 2 }`. Quoting `step`'s own description: *"A value of 2 for add_to_fermentation would mean to add during the second fermentation step."*
- The hop oil fields were flat on an addition rather than nested under `oil_content`.

## What is now closed, and what is not

Closed to unknown keys: `CultureInformation`, `CultureAdditionType`, `EquipmentItemType`, `FermentableType`, `FermentableAdditionType`, `VarietyInformation`, `MiscellaneousType`, `MiscellaneousAdditionType`, `WaterType`.

Still open, each blocked on a question for the working group rather than on effort, and each keeping today's behaviour until answered:

| Type | Why |
| --- | --- |
| `HopAdditionType` | Recipe examples put the whole variety record (`type`, `notes`, `substitutes`, `inventory`, `oil_content`) on an addition. Either the examples are wrong or additions are too narrow. |
| `RecipeStyleType` | The importer fills it with the style's gravity, IBU, colour and ABV ranges, which BeerXML carries inside a recipe's `STYLE` block. I deliberately did not change the importer, because either answer makes it correct. |
| `WaterAdditionType` | An example records the `pH` of the water added. Intersects #218 and #208. |
| `StyleType` | The BJCP and BA guides carry 38 keys it does not declare: style identity (`category_id`, `style_id`, `tags`), prose sections (`history`, `comments`, `entry_instructions`), and Spanish and Portuguese translations of the BJCP 2021 text. |

That last one is 3,163 of the 3,240 rejections and I do not think those files are simply junk: they suggest `StyleType` does not cover what a style guide actually contains. It deserves its own issue, which I will open with the detail.

A ratchet in `tests/schema-conventions.test.js` tracks those four, so the list can only shrink and a newly added composed type cannot join it.

## Type of change

- [x] Schema change, additive in effect (see Compatibility)
- [x] Tooling (BeerXML importer)
- [x] Test corpus

## Compatibility

**Does a document valid against the current release stay valid?** Yes, if it was actually valid. The keys these types now reject were never declared by the format; they were being silently discarded. A consumer that was *relying* on that discarding will now see a validation error, which is the point.

**Does existing software keep working?** Reading, yes. Writing, only if it was writing keys the format never had. Anything that consumed the bundled BeerXML importer's output gets a behaviour change, and a strictly better one: dry hops now convert as dry hops.

## Checklist

- [x] `npm test` passes locally (129 tests)
- [x] `CHANGELOG.md` has an entry
- [x] Generated files regenerated, not hand-edited
- [x] Rebased onto `main` after #244, including Dependabot's action bumps from #241 and #242

## What to look at

The importer changes in `js/beerxml-to-beerjson.js` are where I would most value your eye, @matty0ung, since they change conversion output rather than just validation. The `USE` to `timing.use` mapping is:

```
boil, first wort, aroma  ->  add_to_boil
mash                     ->  add_to_mash
dry hop, primary, secondary  ->  add_to_fermentation
bottling                 ->  add_to_package
anything else, or absent ->  add_to_boil
```

`first wort` and `aroma` both mapping to the boil is the judgement call: it keeps the `time` value meaningful, which is what a consumer calculating IBUs needs, but it does lose the distinction. If BeerJSON should represent first-wort or flame-out additions distinctly, that is a separate proposal and I would rather hear it than guess.

## Note on review requests

`CODEOWNERS` on `main` still routes specification paths to `@beerjson/beerjson-wg`, which does not include @matty0ung or me. The fix is in `fix/schema-quick-wins`, the next PR. Requesting by hand until then.
