### PR TITLE
Fix fluoride, add the wheat culture type, clarify timing.time

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,28 +1,33 @@
 # BeerJSON code owners
 # These owners are requested for review when someone opens a pull request.
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# beerjson-wg and beerjson-admin overlap only partially, so paths that concern
+# every maintainer list both. A team must have at least write access to the
+# repository or GitHub ignores it here: beerjson-wg has push, beerjson-admin has
+# admin.
 
 # Default owner for everything
-* @beerjson/beerjson-wg
+* @beerjson/beerjson-wg @beerjson/beerjson-admin
 
 # The specification itself. Changes here alter the format every implementer
 # reads and writes, so they need working group review.
-/json/ @beerjson/beerjson-wg
+/json/ @beerjson/beerjson-wg @beerjson/beerjson-admin
 
 # Format decisions and authoring conventions
-/adr/ @beerjson/beerjson-wg
-/SCHEMA_STYLE.md @beerjson/beerjson-wg
+/adr/ @beerjson/beerjson-wg @beerjson/beerjson-admin
+/SCHEMA_STYLE.md @beerjson/beerjson-wg @beerjson/beerjson-admin
 
 # Generated from json/ by `npm run gen-docs`. A pull request that touches these
 # without touching json/ is editing generated output by hand.
-/docs/ @beerjson/beerjson-wg
-/types/ @beerjson/beerjson-wg
+/docs/ @beerjson/beerjson-wg @beerjson/beerjson-admin
+/types/ @beerjson/beerjson-wg @beerjson/beerjson-admin
 
 # Generators, validator, BeerXML importer
-/js/ @beerjson/beerjson-wg
+/js/ @beerjson/beerjson-wg @beerjson/beerjson-admin
 
 # Test corpus
-/tests/ @beerjson/beerjson-wg
+/tests/ @beerjson/beerjson-wg @beerjson/beerjson-admin
 
 # CI, templates, repository policy
 /.github/ @beerjson/beerjson-admin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,20 @@ release. The npm package is still 1.0.2, so none of it has reached consumers.
   a message and ajv's params.
 - **`engines: node >= 22`** declared, and CI runs the suite on Node 22 and 24
   ([#216](https://github.com/beerjson/beerjson/issues/216)).
+- **`WaterBase.fluoride`**, spelled correctly
+  ([#214](https://github.com/beerjson/beerjson/issues/214)). The misspelled
+  `flouride` is kept and marked `deprecated`, so existing documents stay valid
+  and writers can migrate on their own schedule. Readers should accept either
+  and prefer `fluoride` when both are present. This is the first use of the
+  deprecation path that 2020-12 makes possible, and it is what #214 was blocked
+  on.
+- **`wheat` as a culture type**
+  ([#217](https://github.com/beerjson/beerjson/issues/217)). It was a yeast type
+  in BeerXML 1.0 with no BeerJSON equivalent, so a Hefeweizen strain had no
+  correct classification.
+- **Deprecations are visible in the generated output.** The markdown reference
+  marks a deprecated property, and the TypeScript and Flow declarations emit
+  `@deprecated`, so an editor strikes it through at the point of use.
 - **Nine of the thirteen `allOf`-composed types now reject unknown keys**, via
   2020-12's `unevaluatedProperties`: `CultureInformation`,
   `CultureAdditionType`, `EquipmentItemType`, `FermentableType`,
@@ -106,9 +120,16 @@ release. The npm package is still 1.0.2, so none of it has reached consumers.
 - **Kolbach Index** is a percentage, and is now typed as one
   ([#187](https://github.com/beerjson/beerjson/pull/187),
   [#186](https://github.com/beerjson/beerjson/issues/186)).
+- **`TimingType.time` now says what it is measured from**
+  ([#220](https://github.com/beerjson/beerjson/issues/220)). The reference point
+  depends on `use`: forwards from the start of the step for mash, fermentation
+  and packaging additions, backwards from the end for boil additions. The
+  previous description gave only the fermentation case, leaving implementers to
+  infer the boil convention.
 - **Typos** in `beer.json` and `fermentable.json` descriptions
   ([#199](https://github.com/beerjson/beerjson/pull/199),
-  [#200](https://github.com/beerjson/beerjson/pull/200)).
+  [#200](https://github.com/beerjson/beerjson/pull/200)), and "transffered" in
+  `recipe.json` ([#204](https://github.com/beerjson/beerjson/issues/204)).
 - **`$id` values** pointed at the `master` branch, renamed to `main` in
   [#235](https://github.com/beerjson/beerjson/pull/235).
 - **ajv** updated to `^8.20.0`, clearing GHSA-2g4f-4pwh-qvx6, and moved to

--- a/adr/0003-deprecate-rather-than-rename.md
+++ b/adr/0003-deprecate-rather-than-rename.md
@@ -1,0 +1,95 @@
+# ADR-0003: Correct property names by deprecating, not renaming
+
+**Status:** Accepted
+**Date:** 2026-08-21
+
+## Context
+
+Several property names in the format are wrong or inconsistent, and each has sat
+unfixed for years because there was no way to fix one without invalidating every
+existing document:
+
+- `WaterBase.flouride` is a misspelling of fluoride (#214, open since 2024).
+- The format is split between `pH` and `ph`: 3 properties use `pH`
+  (`TimingType.pH`, `WaterType.pH`, `RecipeType.beer_pH`) and 8 use `ph`
+  (`start_ph` and `end_ph` on boil, fermentation, mash and packaging steps, plus
+  `FermentableType.di_ph`) (#208, open since 2023).
+- `FermentableBase.group` was renamed to `grain_group` in #219 as a hard break,
+  because that was the only option available.
+
+On #214 the reason for inaction was stated plainly: a typo in a published schema
+means "we have to keep supporting the incorrect version, and a correct one". The
+options were to break everyone or to live with the mistake permanently, and
+neither is acceptable for an interchange format that other people's files are
+already written in.
+
+[ADR-0002](0002-json-schema-2020-12.md) moved the schemas to 2020-12, which
+provides the `deprecated` annotation. There is now a third option.
+
+## Decision
+
+A misnamed property is corrected by **adding** the correct name and **keeping**
+the old one marked `deprecated: true`, with a description that names the
+replacement. Both spellings validate.
+
+```json
+"fluoride": {
+  "description": "The concentration of fluoride in the water.",
+  "$ref": "measureable_units.json#/$defs/ConcentrationType"
+},
+"flouride": {
+  "deprecated": true,
+  "description": "Misspelling of fluoride, kept so existing documents stay valid. Write fluoride instead; readers should accept either and prefer fluoride when both are present.",
+  "$ref": "measureable_units.json#/$defs/ConcentrationType"
+}
+```
+
+The contract for implementers:
+
+- **Writers** should emit the correct name only. The deprecated name is for
+  reading old files, not for writing new ones.
+- **Readers** must accept both, and prefer the correct name when a document
+  carries both.
+- A deprecated name survives **at least one release** before removal, and its
+  removal is a breaking change announced in the changelog like any other.
+
+The deprecation must be visible where implementers actually look, so the
+generators surface it: the markdown reference marks the property, and the
+TypeScript and Flow declarations emit `@deprecated` so an editor strikes it
+through at the point of use. A deprecation that only exists inside the schema
+file is not much better than a comment.
+
+Every deprecation carries a test asserting that both spellings validate, so
+dropping the old one is a deliberate act with a failing test attached rather
+than a silent break.
+
+## Alternatives considered
+
+**Hard rename, batched into a major release.** Simpler schemas, and one
+migration for implementers instead of a long tail. Rejected because the tail is
+the point: BeerJSON files are archived and emailed, and a reader that cannot
+open a five-year-old recipe has failed at the one job an interchange format has.
+A major release also does not help software that never updates, which for hobby
+brewing applications is a large share of them.
+
+**Keep the misspellings forever and document them.** Zero migration cost, and
+the status quo. Rejected because the format accumulates the mistakes
+permanently, every implementer has to learn each one, and the generated types
+teach the wrong name to anyone using autocomplete.
+
+**`oneOf` on the parent object to accept either spelling but not both.**
+Enforces the exclusivity that the "prefer the correct name" rule handles
+socially. Rejected as disproportionate: it makes the schema significantly harder
+to read for a case that is harmless when it happens, and the error message a
+validator produces for a failed `oneOf` is famously unhelpful.
+
+## Consequences
+
+- **Easier:** #214 shipped. #208 has a path that does not break anyone. Future
+  naming mistakes stop being permanent.
+- **Harder:** the schemas carry both spellings for a while, so readers have two
+  code paths per deprecation, and there needs to be the discipline to actually
+  remove old names rather than accumulating them. The changelog and the
+  deprecation tests are what make removal trackable.
+- **Breaking:** nothing on adoption. Each eventual removal is breaking, and gets
+  its own changelog entry and upgrade note.

--- a/adr/README.md
+++ b/adr/README.md
@@ -29,7 +29,8 @@ mark the old one `Superseded by ADR-NNNN`.
 
 ## Index
 
-| ADR                                             | Title                           | Status   |
-| ----------------------------------------------- | ------------------------------- | -------- |
-| [0001](0001-record-format-decisions-as-adrs.md) | Record format decisions as ADRs | Accepted |
-| [0002](0002-json-schema-2020-12.md)             | JSON Schema 2020-12 and `$defs` | Accepted |
+| ADR                                             | Title                                               | Status   |
+| ----------------------------------------------- | --------------------------------------------------- | -------- |
+| [0001](0001-record-format-decisions-as-adrs.md) | Record format decisions as ADRs                     | Accepted |
+| [0002](0002-json-schema-2020-12.md)             | JSON Schema 2020-12 and `$defs`                     | Accepted |
+| [0003](0003-deprecate-rather-than-rename.md)    | Correct property names by deprecating, not renaming | Accepted |

--- a/docs/culture.json.md
+++ b/docs/culture.json.md
@@ -9,7 +9,7 @@ Provides unique properties to identify individual records of a culture.
 |Name|Required|Type|Description|
 |--|--|--|--|
 | **name** | ✅ | string|  |
-| **type** | ✅ | `"ale"`<br/>`"bacteria"`<br/>`"brett"`<br/>`"champagne"`<br/>`"kveik"`<br/>`"lacto"`<br/>`"lager"`<br/>`"malolactic"`<br/>`"mixed-culture"`<br/>`"other"`<br/>`"pedio"`<br/>`"spontaneous"`<br/>`"wine"`|  |
+| **type** | ✅ | `"ale"`<br/>`"bacteria"`<br/>`"brett"`<br/>`"champagne"`<br/>`"kveik"`<br/>`"lacto"`<br/>`"lager"`<br/>`"malolactic"`<br/>`"mixed-culture"`<br/>`"other"`<br/>`"pedio"`<br/>`"spontaneous"`<br/>`"wheat"`<br/>`"wine"`|  |
 | **form** | ✅ | `"liquid"`<br/>`"dry"`<br/>`"slant"`<br/>`"culture"`<br/>`"dregs"`|  |
 | **producer** |  | string|  |
 | **product_id** |  | string|  |

--- a/docs/recipe.json.md
+++ b/docs/recipe.json.md
@@ -19,7 +19,7 @@ RecipeType composes the information stored in a beerjson recipe.
 | **ingredients** | ✅ | [IngredientsType](#ingredientstype)| A collection of all ingredients used for the recipe. |
 | **mash** |  | [MashProcedureType](mash.json.md#mashproceduretype)| This defines the procedure for performing unique mashing processes. |
 | **notes** |  | string|  |
-| **original_gravity** |  | [GravityType](measureable_units.json.md#gravitytype)| The gravity of wort when transffered to the fermenter. |
+| **original_gravity** |  | [GravityType](measureable_units.json.md#gravitytype)| The gravity of wort when transferred to the fermenter. |
 | **final_gravity** |  | [GravityType](measureable_units.json.md#gravitytype)| The gravity of beer at the end of fermentation. |
 | **alcohol_by_volume** |  | [PercentType](measureable_units.json.md#percenttype)|  |
 | **ibu_estimate** |  | [IBUEstimateType](hop.json.md#ibuestimatetype)| The estimated bitterness of the finished beer together with the IBU formula used to calculate it. If the formula is modified in any way, e.g. to support whirlpool/flameout additions, please use `Other` for transparency. |

--- a/docs/timing.json.md
+++ b/docs/timing.json.md
@@ -13,7 +13,7 @@ The timing object fully describes the timing of an addition with options for bas
 
 |Name|Required|Type|Description|
 |--|--|--|--|
-| **time** |  | [TimeType](measureable_units.json.md#timetype)| What time during a process step is added, eg a value of 2 days for a dry hop addition would be added 2 days into the fermentation step. |
+| **time** |  | [TimeType](measureable_units.json.md#timetype)| When during the process step the addition happens. The reference point depends on use: for add_to_fermentation, add_to_mash and add_to_package it is measured forwards from the start of the step, so 2 days for a dry hop means 2 days after fermentation began; for add_to_boil it is measured backwards from the end of the step, following brewing convention, so 40 min means 40 minutes before the end of the boil. |
 | **duration** |  | [TimeType](measureable_units.json.md#timetype)| How long an ingredient addition remains, this was referred to as time in the BeerXML standard. E.G. A 40 minute hop boil additions means to boil for 40 minutes, and a 2 day duration for a dry hop means to remove it after 2 days. |
 | **continuous** |  | boolean| A continuous addition is spread out evenly and added during the entire process step, eg 60 minute IPA by dogfish head takes all ofthe hop additions and adds them throughout the entire boil. |
 | **specific_gravity** |  | [GravityType](measureable_units.json.md#gravitytype)| Used to indicate when an addition is added based on a desired specific gravity. E.G. Add dry hop at when SG is 1.018. |

--- a/docs/water.json.md
+++ b/docs/water.json.md
@@ -17,7 +17,8 @@ WaterBase provides unique properties to identify individual records of  brewing 
 | **iron** |  | [ConcentrationType](measureable_units.json.md#concentrationtype)|  |
 | **nitrate** |  | [ConcentrationType](measureable_units.json.md#concentrationtype)|  |
 | **nitrite** |  | [ConcentrationType](measureable_units.json.md#concentrationtype)|  |
-| **flouride** |  | [ConcentrationType](measureable_units.json.md#concentrationtype)|  |
+| **fluoride** |  | [ConcentrationType](measureable_units.json.md#concentrationtype)| The concentration of fluoride in the water. |
+| **flouride** |  | [ConcentrationType](measureable_units.json.md#concentrationtype)| ⚠️ **Deprecated.** Misspelling of fluoride, kept so existing documents stay valid. Write fluoride instead; readers should accept either and prefer fluoride when both are present. |
 | **sulfate** | ✅ | [ConcentrationType](measureable_units.json.md#concentrationtype)|  |
 | **chloride** | ✅ | [ConcentrationType](measureable_units.json.md#concentrationtype)|  |
 | **sodium** | ✅ | [ConcentrationType](measureable_units.json.md#concentrationtype)|  |

--- a/js/flowtype-formatter.js
+++ b/js/flowtype-formatter.js
@@ -34,8 +34,16 @@ module.exports = {
   formatNestedType: propType =>
     '❌ Cannot generate document for a nested type! ' + propType.type,
 
-  formatPropDefinition: (propName, required, formattedPropType, description) =>
-    `${tab}${tab}${propName}${required ? '' : '?'}: ${formatInt(
+  formatPropDefinition: (
+    propName,
+    required,
+    formattedPropType,
+    description,
+    deprecated
+  ) =>
+    `${
+      deprecated ? `${tab}${tab}/** @deprecated */\n` : ''
+    }${tab}${tab}${propName}${required ? '' : '?'}: ${formatInt(
       formattedPropType
     )},\n`
 }

--- a/js/markdown-formatter.js
+++ b/js/markdown-formatter.js
@@ -48,8 +48,14 @@ ${str}`
   formatNestedType: propType =>
     '❌ Cannot generate document for a nested type! ' + propType.type,
 
-  formatPropDefinition: (propName, required, formattedPropType, description) =>
+  formatPropDefinition: (
+    propName,
+    required,
+    formattedPropType,
+    description,
+    deprecated
+  ) =>
     `| **${propName}** | ${required ? '✅' : ''} | ${formattedPropType}| ${
-      description ? description : ''
-    } |\n`
+      deprecated ? '⚠️ **Deprecated.** ' : ''
+    }${description ? description : ''} |\n`
 }

--- a/js/parser.js
+++ b/js/parser.js
@@ -28,7 +28,8 @@ const parser = formatter => schema => {
       propName,
       requiredList.includes(propName),
       processPropType(propName, propDef),
-      propDef.description
+      propDef.description,
+      propDef.deprecated === true
     )
 
   const processSimpleTypeDefinition = (typeName, typeDef) =>

--- a/js/typescript-formatter.js
+++ b/js/typescript-formatter.js
@@ -34,8 +34,16 @@ module.exports = {
   formatNestedType: propType =>
     '❌ Cannot generate document for a nested type! ' + propType.type,
 
-  formatPropDefinition: (propName, required, formattedPropType, description) =>
-    `${tab}${tab}${propName}${required ? '' : '?'}: ${formatInt(
+  formatPropDefinition: (
+    propName,
+    required,
+    formattedPropType,
+    description,
+    deprecated
+  ) =>
+    `${
+      deprecated ? `${tab}${tab}/** @deprecated */\n` : ''
+    }${tab}${tab}${propName}${required ? '' : '?'}: ${formatInt(
       formattedPropType
     )},\n`
 }

--- a/json/culture.json
+++ b/json/culture.json
@@ -26,6 +26,7 @@
             "other",
             "pedio",
             "spontaneous",
+            "wheat",
             "wine"
           ]
         },

--- a/json/recipe.json
+++ b/json/recipe.json
@@ -58,7 +58,7 @@
           "type": "string"
         },
         "original_gravity": {
-          "description": "The gravity of wort when transffered to the fermenter.",
+          "description": "The gravity of wort when transferred to the fermenter.",
           "$ref": "measureable_units.json#/$defs/GravityType"
         },
         "final_gravity": {

--- a/json/timing.json
+++ b/json/timing.json
@@ -20,7 +20,7 @@
       "additionalProperties": false,
       "properties": {
         "time": {
-          "description": "What time during a process step is added, eg a value of 2 days for a dry hop addition would be added 2 days into the fermentation step.",
+          "description": "When during the process step the addition happens. The reference point depends on use: for add_to_fermentation, add_to_mash and add_to_package it is measured forwards from the start of the step, so 2 days for a dry hop means 2 days after fermentation began; for add_to_boil it is measured backwards from the end of the step, following brewing convention, so 40 min means 40 minutes before the end of the boil.",
           "$ref": "measureable_units.json#/$defs/TimeType"
         },
         "duration": {

--- a/json/water.json
+++ b/json/water.json
@@ -35,7 +35,13 @@
         "nitrite": {
           "$ref": "measureable_units.json#/$defs/ConcentrationType"
         },
+        "fluoride": {
+          "description": "The concentration of fluoride in the water.",
+          "$ref": "measureable_units.json#/$defs/ConcentrationType"
+        },
         "flouride": {
+          "deprecated": true,
+          "description": "Misspelling of fluoride, kept so existing documents stay valid. Write fluoride instead; readers should accept either and prefer fluoride when both are present.",
           "$ref": "measureable_units.json#/$defs/ConcentrationType"
         },
         "sulfate": {

--- a/tests/deprecation.test.js
+++ b/tests/deprecation.test.js
@@ -1,0 +1,108 @@
+/**
+ * A rename is only non-breaking if both spellings really validate. These tests
+ * pin that contract, so removing the deprecated form is a deliberate act with a
+ * failing test attached rather than a silent break of every existing document.
+ */
+const beerjson = require('../index.js')
+
+const waterProfile = extra => ({
+  beerjson: {
+    version: 1.0,
+    profiles: [
+      {
+        name: 'Test water',
+        calcium: { unit: 'mg/l', value: 50 },
+        bicarbonate: { unit: 'mg/l', value: 100 },
+        sulfate: { unit: 'mg/l', value: 50 },
+        chloride: { unit: 'mg/l', value: 50 },
+        sodium: { unit: 'mg/l', value: 10 },
+        magnesium: { unit: 'mg/l', value: 5 },
+        ...extra
+      }
+    ]
+  }
+})
+
+describe('WaterBase fluoride (#214)', () => {
+  const schema = require('../json/water.json').$defs.WaterBase.properties
+
+  test('the corrected spelling exists and is not deprecated', () => {
+    expect(schema.fluoride).toBeDefined()
+    expect(schema.fluoride.deprecated).toBeUndefined()
+  })
+
+  test('the misspelling is still declared, and marked deprecated', () => {
+    expect(schema.flouride).toBeDefined()
+    expect(schema.flouride.deprecated).toBe(true)
+  })
+
+  test('both spellings reference the same type', () => {
+    expect(schema.fluoride.$ref).toBe(schema.flouride.$ref)
+  })
+
+  test('a document using the corrected spelling validates', () => {
+    const result = beerjson.validate(
+      waterProfile({ fluoride: { unit: 'mg/l', value: 1 } })
+    )
+    expect(result).toEqual({ valid: true, errors: [] })
+  })
+
+  test('a document using the deprecated spelling still validates', () => {
+    const result = beerjson.validate(
+      waterProfile({ flouride: { unit: 'mg/l', value: 1 } })
+    )
+    expect(result).toEqual({ valid: true, errors: [] })
+  })
+
+  test('a document using both validates', () => {
+    const result = beerjson.validate(
+      waterProfile({
+        fluoride: { unit: 'mg/l', value: 1 },
+        flouride: { unit: 'mg/l', value: 1 }
+      })
+    )
+    expect(result).toEqual({ valid: true, errors: [] })
+  })
+})
+
+describe('generated output marks deprecated properties', () => {
+  const fs = require('fs')
+  const path = require('path')
+  const read = file => fs.readFileSync(path.join(__dirname, '..', file), 'utf8')
+
+  test('the markdown reference flags it', () => {
+    const docs = read('docs/water.json.md')
+    expect(docs).toMatch(/\*\*flouride\*\*.*Deprecated/)
+  })
+
+  test('the TypeScript declarations carry @deprecated', () => {
+    const types = read('types/ts/beerjson.d.ts')
+    expect(types).toMatch(/@deprecated \*\/\n\s*flouride\?/)
+  })
+})
+
+describe('CultureBase types (#217)', () => {
+  const type = require('../json/culture.json').$defs.CultureBase.properties.type
+
+  test('wheat is an available culture type', () => {
+    expect(type.enum).toContain('wheat')
+  })
+
+  test('a wheat culture validates', () => {
+    const result = beerjson.validate({
+      beerjson: {
+        version: 1.0,
+        cultures: [
+          {
+            name: 'Weihenstephan Weizen',
+            type: 'wheat',
+            form: 'liquid',
+            producer: 'Wyeast',
+            product_id: '3068'
+          }
+        ]
+      }
+    })
+    expect(result).toEqual({ valid: true, errors: [] })
+  })
+})

--- a/tests/generic/recipes.json
+++ b/tests/generic/recipes.json
@@ -195,7 +195,7 @@
                 "unit": "ppm",
                 "value": 0
               },
-              "flouride": {
+              "fluoride": {
                 "unit": "ppm",
                 "value": 0
               },

--- a/tests/generic/water.json
+++ b/tests/generic/water.json
@@ -36,7 +36,7 @@
                 "unit": "ppm",
                 "value": 0.0
               },
-              "flouride": {
+              "fluoride": {
                 "unit": "ppm",
                 "value": 0.0
               },

--- a/types/flow-typed/beerjson.js
+++ b/types/flow-typed/beerjson.js
@@ -53,6 +53,7 @@ export type CultureBase = {|
     | 'other'
     | 'pedio'
     | 'spontaneous'
+    | 'wheat'
     | 'wine',
   form: 'liquid' | 'dry' | 'slant' | 'culture' | 'dregs',
   producer?: string,
@@ -668,6 +669,8 @@ export type WaterBase = {|
   iron?: ConcentrationType,
   nitrate?: ConcentrationType,
   nitrite?: ConcentrationType,
+  fluoride?: ConcentrationType,
+  /** @deprecated */
   flouride?: ConcentrationType,
   sulfate: ConcentrationType,
   chloride: ConcentrationType,

--- a/types/ts/beerjson.d.ts
+++ b/types/ts/beerjson.d.ts
@@ -52,6 +52,7 @@ declare namespace BeerJSON {
       | 'other'
       | 'pedio'
       | 'spontaneous'
+      | 'wheat'
       | 'wine'
     form: 'liquid' | 'dry' | 'slant' | 'culture' | 'dregs'
     producer?: string
@@ -667,6 +668,8 @@ declare namespace BeerJSON {
     iron?: ConcentrationType
     nitrate?: ConcentrationType
     nitrite?: ConcentrationType
+    fluoride?: ConcentrationType
+    /** @deprecated */
     flouride?: ConcentrationType
     sulfate: ConcentrationType
     chloride: ConcentrationType


### PR DESCRIPTION
Fourth of the stack. Four small issues, all open between one and three years.

**#214, `flouride`.** Adds `fluoride` and keeps the misspelling marked `deprecated`, so existing documents stay valid. This is the first use of the deprecation path 2020-12 gave us, which is what the issue was waiting on. The generators now surface it too: the markdown reference marks the property and the TypeScript and Flow declarations emit `@deprecated`, so an editor strikes `flouride` through where you use it.

**#217, `wheat`.** A yeast type in BeerXML 1.0 with no BeerJSON equivalent, so a Hefeweizen strain had nowhere sensible to sit. The issue asked whether the omission was deliberate; nothing in the repo records a reason.

**#220, `TimingType.time`.** The description only covered the fermentation case, leaving the boil convention (measured back from the end of the step) to be inferred. Now states the reference point for each `use`.

**#204,** a typo in a `recipe.json` description.

Also adds ADR-0003 on the deprecation policy, and fixes CODEOWNERS: `main` currently routes every specification path to `@beerjson/beerjson-wg`, which does not include @matty0ung or me, so nobody reviewing gets auto-requested. Paths that concern all maintainers now list both teams.

`tests/deprecation.test.js` pins that both spellings validate, so dropping `flouride` later needs a deliberate change with a failing test attached.

No document valid today becomes invalid.
