### PR TITLE
Define what goes in beerjson.version, and prepare release 1.1.0

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh issue list --limit 100 --state open --json number,title,createdAt,updatedAt,labels,comments,author --template '{{range .}}#{{.number}} [{{.createdAt|timeago}}] \\({{len .comments}}c\\) {{.title}} — @{{.author.login}} {{range .labels}}[{{.name}}]{{end}} *)"
+    ]
+  }
+}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -3,12 +3,44 @@ name: Publish beerJSON NPM package
 on:
   release:
     types: [published]
+  # Run manually to check that NPM_TOKEN still authenticates, before creating a
+  # release. Nothing is published on this path.
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  # Authenticates against the registry and builds the tarball without uploading
+  # it. `npm whoami` fails with E401 or ENEEDAUTH if the token is expired,
+  # revoked, or missing.
+  verify-auth:
+    name: Verify registry credentials
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+
+      - name: Who does NPM_TOKEN authenticate as?
+        run: npm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Build the tarball without publishing
+        run: npm publish --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   publish:
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -24,6 +56,17 @@ jobs:
       - run: npm ci
 
       - run: npm test
+
+      # The release tag must match the version in package.json, or a release
+      # publishes something other than what it claims to.
+      - name: Check the tag matches package.json
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg="$(node -p 'require("./package.json").version')"
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::release tag $GITHUB_REF_NAME does not match package.json version $pkg"
+            exit 1
+          fi
 
       - uses: JS-DevTools/npm-publish@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,29 @@ than entries written at the time.
 
 ## [Unreleased]
 
-Everything below has been on `main` since 1.0.2 (October 2021) without a
-release. The npm package is still 1.0.2, so none of it has reached consumers.
+## [1.1.0] - 2026-08-21
 
-### Changed (breaking)
+Format version **1.1**. The first release since October 2021: everything below
+had accumulated on `main` without reaching consumers.
+
+No document that was valid against 1.0.2 becomes invalid. The schemas are
+stricter, but only about keys and values that were never part of the format and
+were going undetected.
+
+> **Upgrade notes**
+>
+> - **Schema consumers**: the schemas are now JSON Schema 2020-12, so a
+>   validator supporting that draft is required, and type definitions moved from
+>   `definitions` to `$defs`. Code that resolves `$ref` pointers properly needs
+>   no change; code that string-matches `#/definitions/` does.
+> - **TypeScript consumers**: `GraphicType` is now `PackagingGraphicType`, which
+>   is what the schema always called it, and `DensityUnitType` is gone. Neither
+>   described anything the schema contained.
+> - **Anyone writing documents**: write `"version": 1.1`. The `2.01` and `2.06`
+>   values that the examples used to show still validate but are deprecated. See
+>   [ADR-0004](adr/0004-format-version-numbering.md).
+
+### Changed
 
 - **Schemas migrated to JSON Schema 2020-12, and `definitions` renamed to
   `$defs`.** draft-07 has no `deprecated` keyword, which is the only way to
@@ -25,16 +44,20 @@ release. The npm package is still 1.0.2, so none of it has reached consumers.
   ([#214](https://github.com/beerjson/beerjson/issues/214),
   [#208](https://github.com/beerjson/beerjson/issues/208)), and no
   `unevaluatedProperties`, which is the only way an `allOf`-composed type can
-  reject unknown keys. All 46 test documents validate unchanged; a consumer that
-  resolves `$ref` pointers properly is unaffected, but one that string-matches
-  `#/definitions/` will not find the types. See
+  reject unknown keys. All 46 test documents validate unchanged. See
   [ADR-0002](adr/0002-json-schema-2020-12.md).
-- **`FermentableBase.group` renamed to `grain_group`**
-  ([#219](https://github.com/beerjson/beerjson/pull/219)). `group` was never a
-  valid key for the value it held.
+- **`beerjson.version` is now constrained and documented**
+  ([ADR-0004](adr/0004-format-version-numbering.md)). It was a bare `number`
+  with no constraint and no documentation, so nothing agreed on what belonged in
+  it: 22 of the repository's own documents said `2.01`, 24 said `2.06`, the
+  BeerXML importer hardcoded `2.06`, and the README called the format 1.0. It is
+  the format version, `MAJOR.MINOR`, distinct from the npm package version, and
+  the schema now enumerates the versions it accepts. The `2.0x` development
+  snapshot values are kept and marked deprecated, because the published examples
+  showed them for five years and implementations copied them.
 - **`DensityUnitType` removed** from `measureable_units.json`
   ([#234](https://github.com/beerjson/beerjson/pull/234)). It duplicated
-  `GravityUnitType` and no type referenced it.
+  `GravityUnitType` and no type referenced it, so no document could have used it.
 
 ### Added
 
@@ -115,6 +138,10 @@ release. The npm package is still 1.0.2, so none of it has reached consumers.
   `producer` on cultures, `add_to_fermentation_step: N` where `TimingType`
   expresses exactly that as `timing.step`, and the hop oil fields flat on an
   addition rather than nested under `oil_content`.
+- **The BeerXML importer wrote an invalid `group` key** on fermentable
+  additions, where the schema has always called it `grain_group`
+  ([#219](https://github.com/beerjson/beerjson/pull/219)). The schema was not
+  changed, so this affects only files the importer produced.
 - **`packaging_vessel.graphics` and the `misc.json` root** had JSON Schema
   authoring errors ([#222](https://github.com/beerjson/beerjson/pull/222)).
 - **Kolbach Index** is a percentage, and is now typed as one

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,12 +63,20 @@ question is likely to be asked again.
 Classify every schema change before proposing it:
 
 - **Additive** (minor release): a new optional property, a new value in an
-  existing enum, a new type, a clarified `description`. A document valid against
-  the previous version stays valid, and existing software keeps working.
+  existing enum, a new type. A document valid against the previous version stays
+  valid, and software built against the new version reads old documents.
 - **Breaking** (major release): renaming or removing a property, changing a
   property's type, adding a `required` entry, removing an enum value, or
   tightening a constraint. Existing files or existing implementations stop
   working.
+- **Neither**: a clarified `description`, which leaves every document's validity
+  untouched. Ships as a patch release of the package, format version unchanged.
+
+Note that an additive change does not guarantee that _older_ software reads a
+_newer_ document. A new enum value is rejected by an older validator, and a
+property added on a closed type is too.
+[ADR-0004](adr/0004-format-version-numbering.md) sets out what each bump does
+and does not promise.
 
 Breaking changes are batched into a single release rather than dribbled out, and
 are announced in [CHANGELOG.md](CHANGELOG.md) with upgrade notes. Where a

--- a/adr/0004-format-version-numbering.md
+++ b/adr/0004-format-version-numbering.md
@@ -1,0 +1,131 @@
+# ADR-0004: Format version numbering
+
+**Status:** Accepted
+**Date:** 2026-08-21
+
+## Context
+
+Every BeerJSON document is required to carry `beerjson.version`, and nothing in
+the repository says what to put there.
+
+`VersionType` is declared as a bare `number` with no constraint, so any value
+validates. The repository does not agree with itself about which value is right:
+
+- 22 documents under `tests/` declare `2.01`
+- 24 declare `2.06`
+- The bundled BeerXML importer hardcodes `2.06` into everything it converts
+- The README describes the contents as "the BeerJSON 1.0 specification"
+- The npm package and the git tags say `1.0.x`
+
+The `2.0x` values are inherited from BeerXML 2, the unfinished draft BeerJSON was
+derived from, and were never revisited when #176 declared BeerJSON 1.0. The
+result is that a consumer cannot use the field for the one thing it exists for,
+which is deciding whether it understands the document in front of it, and an
+implementer writing a file has no way to find out what to emit.
+
+There is a second, quieter problem. Because the value is a JSON number, `1.10`
+and `1.1` are the same value, so a numbering scheme that ever reaches a
+two-digit minor version silently collides. `1.0` is also indistinguishable from
+`1`, since JSON has no decimal type.
+
+## Decision
+
+**`beerjson.version` is the version of the format, not of the npm package.** A
+package release that changes no schema does not move it. Dependency bumps and
+tooling fixes never move it.
+
+**It has exactly two components, `MAJOR.MINOR`.** Never `MAJOR.MINOR.PATCH`: a
+JSON number cannot carry three components, and a format has no meaningful patch
+level, since a change to what documents may contain is at least a minor.
+
+- **MAJOR** increments when a document valid against the previous version stops
+  being valid: a property removed, a property's type changed, a new `required`
+  entry, an enum value withdrawn.
+- **MINOR** increments when the format gains something without invalidating
+  anything: a new optional property, a new enum value, a new type, a corrected
+  description. Closing a type to unknown keys is a minor, because the keys it
+  starts rejecting were never valid.
+
+**Minor versions stay single-digit while the field is a number.** On reaching
+`x.9`, the next release is a major, or the field moves to a string in a major.
+
+**`VersionType` enumerates the versions the schema can validate**, rather than
+accepting any number. The development-snapshot values are kept in a branch
+marked `deprecated`, following [ADR-0003](0003-deprecate-rather-than-rename.md):
+
+```json
+"VersionType": {
+  "description": "The version of the BeerJSON format this document is written against, as MAJOR.MINOR. Note that JSON has no decimal type, so 1.0 is written as the number 1.",
+  "oneOf": [
+    { "type": "number", "enum": [1.0, 1.1] },
+    {
+      "deprecated": true,
+      "description": "Development-snapshot versions inherited from the unfinished BeerXML 2 draft. Accepted so existing documents stay valid; write 1.1 instead.",
+      "type": "number",
+      "enum": [2.01, 2.06]
+    }
+  ]
+}
+```
+
+Keeping `2.01` and `2.06` valid is not politeness. They are what the published
+examples showed for five years, so implementations copied them: every example
+document in Werb, an independent consumer, declares `2.06` because it was
+copied from this repository's own fixtures. Rejecting the value outright would
+invalidate real files for a cosmetic gain, and would make this release a major
+for no benefit to anyone.
+
+A schema accepts its own version and every earlier one it is compatible with, so
+a 1.1 reader accepts a 1.0 document. A document declaring a version in neither
+branch fails with an error that names the version, rather than failing obscurely
+somewhere deeper or, as today, passing while being misunderstood.
+
+The current format version is therefore **1.1**, and the enum is the single
+source of truth for it: `js/format-version.js` derives the current and supported
+versions from the schema, the importer emits the current one, and a test asserts
+every document under `tests/` declares a supported version.
+
+## Alternatives considered
+
+**Keep `2.06` and continue the BeerXML 2 numbering.** It is what most of the
+test corpus and the importer already do, so it is the cheapest option and has
+some claim to being the original intent. Rejected because the project published
+itself as 1.0 in #176, tagged 1.0.x, and describes itself as 1.0 in the README
+and the documentation title. Declaring `2.06` in documents while calling the
+format 1.0 everywhere else would preserve exactly the confusion this ADR exists
+to end. It would also imply a relationship to a BeerXML 2 draft that was never
+finished and that BeerJSON has long since diverged from.
+
+**Leave `VersionType` unconstrained and document the expected value.** Least
+disruptive. Rejected because the field's only purpose is machine consumption; a
+constraint no validator enforces is a comment, and the present state is the
+evidence for that, with the repository's own documents disagreeing for five
+years without anything noticing.
+
+**Make the version a string** (`"1.1"`), which removes the two-digit-minor
+collision and allows a patch component and prerelease tags. This is the right
+long-term answer. Rejected for now because `version` is required on every
+document, so changing its type invalidates every BeerJSON file in existence,
+which is the most expensive possible break for the least urgent problem. It is
+recorded here as the thing to do in the next major.
+
+**Tie the format version to the package version.** Superficially simpler, one
+number to think about. Rejected because they answer different questions: a
+consumer reading a file needs to know which spec it follows, while a package
+version has to move for a dependency bump or a tooling fix that leaves the format
+untouched. Conflating them would either force pointless format version bumps or
+freeze the package version.
+
+## Consequences
+
+- **Easier:** a consumer can decide from the version field alone whether it
+  understands a document; an implementer has a documented answer for what to
+  write; an unsupported version fails with a clear error.
+- **Harder:** every release with schema changes must extend the `VersionType`
+  enum, which is a deliberate step that is easy to forget. The test asserting the
+  test corpus declares a supported version is what catches it.
+- **Breaking:** nothing. Documents declaring `2.01` or `2.06` keep validating,
+  and every other value that used to pass was passing only because the field was
+  unconstrained. Software emitting `2.06` should move to `1.1`, but on its own
+  schedule; the deprecated branch will be removed in a future major with the
+  usual notice.

--- a/adr/0004-format-version-numbering.md
+++ b/adr/0004-format-version-numbering.md
@@ -42,9 +42,48 @@ level, since a change to what documents may contain is at least a minor.
   being valid: a property removed, a property's type changed, a new `required`
   entry, an enum value withdrawn.
 - **MINOR** increments when the format gains something without invalidating
-  anything: a new optional property, a new enum value, a new type, a corrected
-  description. Closing a type to unknown keys is a minor, because the keys it
-  starts rejecting were never valid.
+  anything: a new optional property, a new enum value, a new type. Closing a
+  type to unknown keys is a minor, because the keys it starts rejecting were
+  never valid.
+- **Neither** increments for a change that leaves every document's validity
+  untouched, such as correcting a description. That ships as a patch release of
+  the package with the format version unchanged.
+
+### What a version bump promises
+
+An interchange format has two directions of compatibility, and they are not
+equivalent:
+
+|                      | New software, old document | Old software, new document |
+| -------------------- | -------------------------- | -------------------------- |
+| Patch (package only) | valid                      | valid                      |
+| MINOR                | valid                      | **may be rejected**        |
+| MAJOR                | may be rejected            | may be rejected            |
+
+**A MINOR bump promises only that new software reads old documents.** It does
+not promise the reverse. Semantic Versioning's "backward compatible manner" is
+written for an API consumer, where adding something is safe; for a data format,
+a document written against a newer version can fail against an older schema.
+Three ways it fails, in increasing severity:
+
+- **A new optional property is ignored** where the type it sits on is open to
+  unknown keys. The document validates and the value is discarded.
+- **A property added alongside a deprecated one loses data silently.** A reader
+  that knows only `flouride` discards a document's `fluoride` and reports
+  nothing.
+- **A new enum value is rejected outright.** An enum is closed in every version,
+  so a document using `wheat` as a culture type fails against the 1.0 schema
+  rather than degrading.
+
+From 1.1 onwards most composed types declare `unevaluatedProperties: false`, so
+the first case increasingly behaves like the third: an older validator rejects a
+newer document rather than ignoring the addition.
+
+None of this argues for calling such changes MAJOR, which would make every
+addition a breaking release. It argues for saying so plainly: a reader should
+accept an unknown format version it can parse, and treat unrecognised properties
+and enum values as data it does not understand rather than as grounds for
+rejecting the document.
 
 **Minor versions stay single-digit while the field is a number.** On reaching
 `x.9`, the next release is a major, or the field moves to a string in a major.

--- a/adr/README.md
+++ b/adr/README.md
@@ -34,3 +34,4 @@ mark the old one `Superseded by ADR-NNNN`.
 | [0001](0001-record-format-decisions-as-adrs.md) | Record format decisions as ADRs                     | Accepted |
 | [0002](0002-json-schema-2020-12.md)             | JSON Schema 2020-12 and `$defs`                     | Accepted |
 | [0003](0003-deprecate-rather-than-rename.md)    | Correct property names by deprecating, not renaming | Accepted |
+| [0004](0004-format-version-numbering.md)        | Format version numbering                            | Accepted |

--- a/docs/measureable_units.json.md
+++ b/docs/measureable_units.json.md
@@ -345,9 +345,9 @@ RegExp pattern: `\d{4}-\d{2}-\d{2}|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}`
 `"very low"`<br/>`"low"`<br/>`"medium low"`<br/>`"medium"`<br/>`"medium high"`<br/>`"high"`<br/>`"very high"`
 ## VersionType 
 
-*no description yet*
+The version of the BeerJSON format this document is written against, as MAJOR.MINOR. Note that JSON has no decimal type, so 1.0 is written as the number 1.
 
-number
+ `1`<br/>`1.1` or  `2.01`<br/>`2.06`
 ## ViscosityUnitType 
 
 *no description yet*

--- a/js/beerxml-to-beerjson.js
+++ b/js/beerxml-to-beerjson.js
@@ -9,6 +9,8 @@ const {
   lowerCase
 } = require('lodash')
 
+const { CURRENT_VERSION } = require('./format-version')
+
 const parseBool = s => String(s).toUpperCase() === 'TRUE'
 const getArrayNode = node =>
   Array.from(isNil(node) ? [] : Array.isArray(node) ? node : [node])
@@ -395,7 +397,7 @@ const importFromBeerXml = xml => {
 
     const beerJSON = {
       beerjson: {
-        version: 2.06,
+        version: CURRENT_VERSION,
         recipes: [recipe]
       }
     }

--- a/js/flowtype-formatter.js
+++ b/js/flowtype-formatter.js
@@ -11,12 +11,20 @@ module.exports = {
 
   addPropListWrapper: str => (str ? `{|\n${str}${tab}|}\n` : ''),
 
+  // A numeric enum is a union of number literals, not of quoted strings.
   formatEnum: enumValues =>
-    enumValues.reduce((str, val) => str + ` | "${val}"`, ''),
+    enumValues.reduce(
+      (str, val) =>
+        str + (typeof val === 'number' ? ` | ${val}` : ` | "${val}"`),
+      ''
+    ),
 
   formatArray: (ref, formattedType) => `${formattedType}[]`,
 
-  formatOneOf: (str, formattedRef) => str + ` | ${formattedRef}`,
+  // A branch that is itself a union already carries a leading `|`; keeping both
+  // would emit `| | "a"`.
+  formatOneOf: (str, formatted) =>
+    str + ` | ${String(formatted).replace(/^\s*\|\s*/, '')}`,
 
   formatParsedTypeRef: ({ typeName, fileName }) => typeName,
 

--- a/js/format-version.js
+++ b/js/format-version.js
@@ -1,0 +1,19 @@
+/**
+ * The format version, derived from the schema so there is one source of truth.
+ *
+ * `VersionType` is a oneOf: the first branch enumerates the current versions,
+ * the second the deprecated development-snapshot values. See ADR-0004.
+ */
+const { VersionType } = require('../json/measureable_units.json').$defs
+
+const [current, deprecated] = VersionType.oneOf
+
+const SUPPORTED_VERSIONS = current.enum
+const DEPRECATED_VERSIONS = deprecated.enum
+const CURRENT_VERSION = Math.max(...SUPPORTED_VERSIONS)
+
+module.exports = {
+  CURRENT_VERSION,
+  SUPPORTED_VERSIONS,
+  DEPRECATED_VERSIONS
+}

--- a/js/markdown-formatter.js
+++ b/js/markdown-formatter.js
@@ -17,10 +17,10 @@ ${formattedDef}
 ${str}`
       : '',
   formatEnum: enumValues =>
-    enumValues.reduce(
-      (str, val) => (str ? str + `<br/>\`"${val}"\`` : `\`"${val}"\``),
-      ''
-    ),
+    enumValues.reduce((str, val) => {
+      const rendered = typeof val === 'number' ? `\`${val}\`` : `\`"${val}"\``
+      return str ? str + `<br/>${rendered}` : rendered
+    }, ''),
   formatArray: (ref, formattedType) => `array of ${formattedType}`,
 
   formatOneOf: (str, formattedRef) =>

--- a/js/parser.js
+++ b/js/parser.js
@@ -18,9 +18,10 @@ const parser = formatter => schema => {
   const processArray = items =>
     formatter.formatArray(items.$ref, processPropType('items', items))
 
+  // A branch is either a $ref to a named type or an inline schema.
   const processOneOf = types =>
     types
-      .map(({ $ref }) => processTypeRef($ref))
+      .map((branch, index) => processPropType(`oneOf[${index}]`, branch))
       .reduce(formatter.formatOneOf, '')
 
   const processPropDefinition = requiredList => ([propName, propDef]) =>

--- a/js/typescript-formatter.js
+++ b/js/typescript-formatter.js
@@ -11,12 +11,20 @@ module.exports = {
 
   addPropListWrapper: str => (str ? `{\n${str}${tab}}\n` : ''),
 
+  // A numeric enum is a union of number literals, not of quoted strings.
   formatEnum: enumValues =>
-    enumValues.reduce((str, val) => str + ` | "${val}"`, ''),
+    enumValues.reduce(
+      (str, val) =>
+        str + (typeof val === 'number' ? ` | ${val}` : ` | "${val}"`),
+      ''
+    ),
 
   formatArray: (ref, formattedType) => `${formattedType}[]`,
 
-  formatOneOf: (str, formattedRef) => str + ` | ${formattedRef}`,
+  // A branch that is itself a union already carries a leading `|`; keeping both
+  // would emit `| | "a"`.
+  formatOneOf: (str, formatted) =>
+    str + ` | ${String(formatted).replace(/^\s*\|\s*/, '')}`,
 
   formatParsedTypeRef: ({ typeName, fileName }) => typeName,
 

--- a/json/measureable_units.json
+++ b/json/measureable_units.json
@@ -539,7 +539,25 @@
       ]
     },
     "VersionType": {
-      "type": "number"
+      "description": "The version of the BeerJSON format this document is written against, as MAJOR.MINOR. Note that JSON has no decimal type, so 1.0 is written as the number 1.",
+      "oneOf": [
+        {
+          "type": "number",
+          "enum": [
+            1,
+            1.1
+          ]
+        },
+        {
+          "deprecated": true,
+          "description": "Development-snapshot versions inherited from the unfinished BeerXML 2 draft. Accepted so existing documents stay valid; write 1.1 instead.",
+          "type": "number",
+          "enum": [
+            2.01,
+            2.06
+          ]
+        }
+      ]
     },
     "ViscosityUnitType": {
       "type": "string",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beerjson/beerjson",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "BeerJSON format",
   "main": "index.js",
   "types": "types/ts/beerjson.d.ts",

--- a/tests/converted/GenericOneHF.json
+++ b/tests/converted/GenericOneHF.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "recipes": [
       {
         "name": "Generic",

--- a/tests/converted/Kolsh.json
+++ b/tests/converted/Kolsh.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "recipes": [
       {
         "name": "Lloyd&#39;s Krispy Kolsch",

--- a/tests/converted/Londonpride.json
+++ b/tests/converted/Londonpride.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "recipes": [
       {
         "name": "London pride",

--- a/tests/converted/RRSummerBitter.json
+++ b/tests/converted/RRSummerBitter.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "recipes": [
       {
         "name": "RR Summer Bitter",

--- a/tests/converted/punk-ipa-2010-current.json
+++ b/tests/converted/punk-ipa-2010-current.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "recipes": [
       {
         "name": "PUNK IPA 2010 - CURRENT",

--- a/tests/format-version.test.js
+++ b/tests/format-version.test.js
@@ -1,0 +1,103 @@
+/**
+ * The version contract from ADR-0004. `beerjson.version` was unconstrained and
+ * the repository's own documents disagreed about what belonged in it for five
+ * years, so every part of the contract is pinned here.
+ */
+const fs = require('fs')
+const path = require('path')
+
+const beerjson = require('../index.js')
+const {
+  CURRENT_VERSION,
+  SUPPORTED_VERSIONS,
+  DEPRECATED_VERSIONS
+} = require('../js/format-version')
+
+const document = version => ({
+  beerjson: {
+    version,
+    hop_varieties: [
+      { name: 'Cascade', origin: 'US', alpha_acid: { unit: '%', value: 5 } }
+    ]
+  }
+})
+
+describe('VersionType', () => {
+  test('the current version is the highest supported one', () => {
+    expect(CURRENT_VERSION).toBe(Math.max(...SUPPORTED_VERSIONS))
+  })
+
+  test('has exactly two components, never MAJOR.MINOR.PATCH', () => {
+    for (const version of [...SUPPORTED_VERSIONS, ...DEPRECATED_VERSIONS]) {
+      expect(String(version).split('.').length).toBeLessThanOrEqual(2)
+    }
+  })
+
+  // A JSON number cannot distinguish 1.10 from 1.1, so a two-digit minor
+  // silently collides with an earlier version. ADR-0004 keeps minors single
+  // digit until the field becomes a string in a future major.
+  test('minor versions stay single-digit', () => {
+    for (const version of SUPPORTED_VERSIONS) {
+      const minor = String(version).split('.')[1]
+      if (minor !== undefined) expect(minor.length).toBe(1)
+    }
+  })
+
+  test.each(SUPPORTED_VERSIONS)('%s validates', version => {
+    expect(beerjson.validate(document(version))).toEqual({
+      valid: true,
+      errors: []
+    })
+  })
+
+  // These were never a published BeerJSON version, but they are what the
+  // examples showed for years, so implementations copied them.
+  test.each(DEPRECATED_VERSIONS)('deprecated %s still validates', version => {
+    expect(beerjson.validate(document(version)).valid).toBe(true)
+  })
+
+  test('the deprecated branch is marked deprecated', () => {
+    const { VersionType } = require('../json/measureable_units.json').$defs
+    expect(VersionType.oneOf[1].deprecated).toBe(true)
+  })
+
+  test.each([0.9, 2.0, 3.0, 1.2])('unknown version %s is rejected', version => {
+    expect(beerjson.validate(document(version)).valid).toBe(false)
+  })
+
+  test('a non-numeric version is rejected', () => {
+    expect(beerjson.validate(document('1.1')).valid).toBe(false)
+  })
+})
+
+describe('the test corpus declares a supported version', () => {
+  const dirs = fs
+    .readdirSync(path.join(__dirname))
+    .filter(entry => entry !== 'xml' && !entry.startsWith('.'))
+    .filter(entry => fs.statSync(path.join(__dirname, entry)).isDirectory())
+
+  const documents = []
+  for (const dir of dirs) {
+    for (const file of fs.readdirSync(path.join(__dirname, dir))) {
+      documents.push([`${dir}/${file}`, path.join(__dirname, dir, file)])
+    }
+  }
+
+  test.each(documents)('%s', (_name, file) => {
+    const { version } = JSON.parse(fs.readFileSync(file, 'utf8')).beerjson
+    expect(SUPPORTED_VERSIONS).toContain(version)
+  })
+})
+
+describe('the BeerXML importer', () => {
+  const importFromBeerXml = require('../js/beerxml-to-beerjson')
+
+  test('emits the current format version, not a hardcoded one', () => {
+    const xml = fs.readFileSync(
+      path.join(__dirname, 'xml', 'Kolsh.xml'),
+      'utf8'
+    )
+    const converted = JSON.parse(importFromBeerXml(xml))
+    expect(converted.beerjson.version).toBe(CURRENT_VERSION)
+  })
+})

--- a/tests/generic/beer.json
+++ b/tests/generic/beer.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "recipes": [],
     "styles": []
   }

--- a/tests/generic/boil.json
+++ b/tests/generic/boil.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "boil": [
       {
         "name": "60 minute boil",

--- a/tests/generic/cultures.json
+++ b/tests/generic/cultures.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "cultures": [
       {
         "name": "Ole English Ale Yeast",

--- a/tests/generic/equipment.json
+++ b/tests/generic/equipment.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "equipments": [
       {
         "name": "Default set",

--- a/tests/generic/fermentable.json
+++ b/tests/generic/fermentable.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "fermentables": [
       {
         "name": "name",

--- a/tests/generic/fermentation.json
+++ b/tests/generic/fermentation.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "fermentations": [
       {
         "name": "Ale, Single Stage",

--- a/tests/generic/hop_varieties.json
+++ b/tests/generic/hop_varieties.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "hop_varieties": [
       {
         "name": "name",

--- a/tests/generic/mash.json
+++ b/tests/generic/mash.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "mashes": [
       {
         "name": "mash",

--- a/tests/generic/miscellaneous_ingredients.json
+++ b/tests/generic/miscellaneous_ingredients.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "miscellaneous_ingredients": [
       {
         "name": "name",

--- a/tests/generic/packaging.json
+++ b/tests/generic/packaging.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "packaging": [
       {
         "name": "Kegged",

--- a/tests/generic/recipes.json
+++ b/tests/generic/recipes.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "recipes": [
       {
         "name": "my recipe",

--- a/tests/generic/styles.json
+++ b/tests/generic/styles.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "styles": [
       {
         "name": "name",

--- a/tests/generic/water.json
+++ b/tests/generic/water.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "profiles": [
       {
         "name": "metropolis city water",

--- a/tests/real/BrettDosedKegsSaison.json
+++ b/tests/real/BrettDosedKegsSaison.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "recipes": [
       {
         "name": "MTF Spelt Saison brett C added at kegging",

--- a/tests/real/CheaterHops.json
+++ b/tests/real/CheaterHops.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "recipes": [
       {
         "name": "Cheater hops",

--- a/tests/real/CorianderSpice.json
+++ b/tests/real/CorianderSpice.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.01,
+    "version": 1.1,
     "miscellaneous_ingredients": [
       {
         "name": "Coriander",

--- a/tests/real/CrystalMaltSpecialtyGrain.json
+++ b/tests/real/CrystalMaltSpecialtyGrain.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.01,
+    "version": 1.1,
     "fermentables": [
       {
         "name": "Crystal 40 L",

--- a/tests/real/EquipmentSet.json
+++ b/tests/real/EquipmentSet.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "equipments": [
       {
         "name": "All Grain - Large 10 Gal/38 l - Stainless",

--- a/tests/real/FermentableRecord.json
+++ b/tests/real/FermentableRecord.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.01,
+    "version": 1.1,
     "fermentables": [
       {
         "name": "Pale 2-row Malt",

--- a/tests/real/FirstWortHopAddition.json
+++ b/tests/real/FirstWortHopAddition.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "recipes": [
       {
         "name": "First Wort Hop Addition",

--- a/tests/real/HopRecordWithAllFields.json
+++ b/tests/real/HopRecordWithAllFields.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.01,
+    "version": 1.1,
     "hop_varieties": [
       {
         "name": "Super Hops",

--- a/tests/real/HopWithRequiredFieldsOnly.json
+++ b/tests/real/HopWithRequiredFieldsOnly.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.01,
+    "version": 1.1,
     "hop_varieties": [
       {
         "name": "Cascade",

--- a/tests/real/HoppedExtract.json
+++ b/tests/real/HoppedExtract.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.01,
+    "version": 1.1,
     "fermentables": [
       {
         "name": "Fustons Hopped Amber",

--- a/tests/real/IrishMoss.json
+++ b/tests/real/IrishMoss.json
@@ -37,6 +37,6 @@
         "type": "all grain"
       }
     ],
-    "version": 2.01
+    "version": 1.1
   }
 }

--- a/tests/real/KettleSour.json
+++ b/tests/real/KettleSour.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.01,
+    "version": 1.1,
     "recipes": [
       {
         "name": "Kettle Sour",

--- a/tests/real/MashDecoction.json
+++ b/tests/real/MashDecoction.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.01,
+    "version": 1.1,
     "mashes": [
       {
         "name": "Two Step Temperature, 68C",

--- a/tests/real/MashSingleStepInfusion.json
+++ b/tests/real/MashSingleStepInfusion.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.01,
+    "version": 1.1,
     "mashes": [
       {
         "name": "Single Step Infusion, 68 C",

--- a/tests/real/MashTwoStepTemperatureWithSparge.json
+++ b/tests/real/MashTwoStepTemperatureWithSparge.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.01,
+    "version": 1.1,
     "mashes": [
       {
         "name": "Two Step Temperature, 68C",

--- a/tests/real/MedievalAle.json
+++ b/tests/real/MedievalAle.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "recipes": [
       {
         "name": "#20 1058 Medieval Ale",

--- a/tests/real/SampleWaterProfile.json
+++ b/tests/real/SampleWaterProfile.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.01,
+    "version": 1.1,
     "profiles": [
       {
         "name": "Burton on Trent, UK",

--- a/tests/real/SourFruitedCopitch.json
+++ b/tests/real/SourFruitedCopitch.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.01,
+    "version": 1.1,
     "recipes": [
       {
         "name": "Raspberry Sour copitch",

--- a/tests/real/SourMash.json
+++ b/tests/real/SourMash.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.01,
+    "version": 1.1,
     "recipes": [
       {
         "name": "Sour Mash",

--- a/tests/real/SpargeAcidification.json
+++ b/tests/real/SpargeAcidification.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.01,
+    "version": 1.1,
     "recipes": [
       {
         "name": "Sparge Acidification Example",

--- a/tests/real/StyleBohemianPilsner.json
+++ b/tests/real/StyleBohemianPilsner.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.01,
+    "version": 1.1,
     "styles": [
       {
         "name": "Bohemian Pilsner",

--- a/tests/real/StyleDryIrishStoutWithAllFields.json
+++ b/tests/real/StyleDryIrishStoutWithAllFields.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.01,
+    "version": 1.1,
     "styles": [
       {
         "name": "Dry Stout",

--- a/tests/real/YeastWithMorePopularFields.json
+++ b/tests/real/YeastWithMorePopularFields.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.01,
+    "version": 1.1,
     "cultures": [
       {
         "name": "German Ale",

--- a/tests/real/YeastWithRequiredFieldsOnly.json
+++ b/tests/real/YeastWithRequiredFieldsOnly.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.01,
+    "version": 1.1,
     "cultures": [
       {
         "name": "Ole English Ale Yeast",

--- a/tests/real/boil_whirlpool_chill.json
+++ b/tests/real/boil_whirlpool_chill.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.06,
+    "version": 1.1,
     "boil": [
       {
         "name": "60 minute boil",

--- a/tests/styles/ba_styleguide-2017.json
+++ b/tests/styles/ba_styleguide-2017.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.01,
+    "version": 1.1,
     "styles": [
       {
         "name": "Ordinary Bitter",

--- a/tests/styles/bjcp_styleguide-2015.json
+++ b/tests/styles/bjcp_styleguide-2015.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.01,
+    "version": 1.1,
     "styles": [
       {
         "name": "American Light Lager",

--- a/tests/styles/bjcp_styleguide-2021.json
+++ b/tests/styles/bjcp_styleguide-2021.json
@@ -1,6 +1,6 @@
 {
   "beerjson": {
-    "version": 2.01,
+    "version": 1.1,
     "styles": [
       {
         "name": "American Light Lager",

--- a/types/flow-typed/beerjson.js
+++ b/types/flow-typed/beerjson.js
@@ -465,7 +465,7 @@ export type QualitativeRangeType =
   | 'medium high'
   | 'high'
   | 'very high'
-export type VersionType = number
+export type VersionType = 1 | 1.1 | 2.01 | 2.06
 export type ViscosityUnitType = 'cP' | 'mPa-s'
 export type MiscellaneousBase = {|
   name: string,

--- a/types/ts/beerjson.d.ts
+++ b/types/ts/beerjson.d.ts
@@ -464,7 +464,7 @@ declare namespace BeerJSON {
     | 'medium high'
     | 'high'
     | 'very high'
-  export type VersionType = number
+  export type VersionType = 1 | 1.1 | 2.01 | 2.06
   export type ViscosityUnitType = 'cP' | 'mPa-s'
   export type MiscellaneousBase = {
     name: string


### PR DESCRIPTION
Fifth of the stack. Settles what goes in `beerjson.version`, and prepares the 1.1.0 release.

## The problem

`beerjson.version` is required on every document and nothing said what to put there. `VersionType` was a bare `number` with no constraint, so the repository disagreed with itself: 22 of its own documents said `2.01`, 24 said `2.06`, the BeerXML importer hardcoded `2.06`, while the README, the tags and the package all said 1.0. A consumer could not use the field for the one thing it exists for.

## The decision

[ADR-0004](https://github.com/beerjson/beerjson/blob/chore/format-version-and-release/adr/0004-format-version-numbering.md). The field is the **format** version, `MAJOR.MINOR`, distinct from the npm package version. `VersionType` now enumerates the versions the schema accepts. `js/format-version.js` derives it from the schema so there is one source of truth: the importer emits it, and a test asserts every document under `tests/` declares a supported one.

`2.01` and `2.06` are kept in a `deprecated` branch rather than rejected. They are what the published examples showed for years, so implementations copied them: every example document in Werb declares `2.06` because it came from this repository's fixtures. Rejecting them would invalidate real files and make this a major release for nobody's benefit.

## What a version bump promises

From your review on #250. Checking your `fluoride` case turned up a harsher one in that same PR: enums are closed in every version, so `wheat` makes a 1.1 document fail outright against 1.0.2 rather than quietly losing a field.

```
culture type "ale":   accepted
culture type "wheat": REJECTED -> must be equal to one of the allowed values
```

So ADR-0004 now says a MINOR bump promises only that new software reads old documents, never the reverse, and lists the three ways an older reader fails. `CONTRIBUTING.md` claimed an additive change meant existing software keeps working; that is corrected, and a third classification added for changes that touch no document's validity, which bump the package and not the format. That covers the point release you suggested, which the format version cannot express with only two components.

## Release 1.1.0

A minor, not a major: no document valid against 1.0.2 becomes invalid. I checked the two candidates. `grain_group` was already the key at v1.0.2 (#219 changed the importer, not the schema), and `DensityUnitType` was never referenced by anything. The schemas are stricter, but only about keys and values that were never part of the format.

The changelog carries upgrade notes for the 2020-12 migration, the `$defs` rename and the TypeScript type renames.

## Also here

`workflow_dispatch` on the publish workflow now runs a `verify-auth` job that authenticates against the registry and builds the tarball without uploading it, so we can check `NPM_TOKEN` before creating a release rather than during one. The publish path also refuses a release whose tag disagrees with `package.json`.

## Two generator bugs fixed on the way

Both the same class as the array crash in #240, both latent until a schema used the construct. `processOneOf` assumed every branch was a `$ref`. The TypeScript and Flow formatters emitted numeric enums as quoted strings which, combined with the `oneOf` separator, produced `| | "1"`; prettier rejected the generated declarations outright. `VersionType` now emits as `1 | 1.1 | 2.01 | 2.06`.

## Compatibility

Documents valid today stay valid, including those declaring `2.01` or `2.06`. Software emitting `2.0x` should move to `1.1` on its own schedule; the deprecated branch goes in a future major with the usual notice.

Verified by packing the tarball, installing it into a clean project, and checking that `1.1`, `1.0`, `2.01` and `2.06` all validate while `1.2` and `"1.1"` are rejected, and that `tsc --strict` accepts both `1.1` and `2.06` from the shipped declarations.
